### PR TITLE
added possibility to configure the binding attribute

### DIFF
--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -40,6 +40,9 @@ Backbone.ModelBinding = (function(){
   return {
     version: "0.1.1",
 
+	attr: "id",
+	radioAttr: "name",
+	
     call: function(view){
       handleFormBindings(view, view.model);
       handleHtmlBindings(view, view.model);
@@ -56,7 +59,7 @@ Backbone.ModelBinding.Conventions = (function(){
     bind: function(selector, view, model){
       view.$(selector).each(function(index){
         var element = view.$(this);
-        var field = element.attr('id');
+        var field = element.attr(Backbone.ModelBinding.attr);
         Backbone.ModelBinding.HelperMethods.bidirectionalBinding.call(view, field, element, model);
       });
     }
@@ -68,7 +71,7 @@ Backbone.ModelBinding.Conventions = (function(){
       var foundElements = [];
       view.$(selector).each(function(index){
         var element = view.$(this);
-        var group_name = element.attr('name');
+        var group_name = element.attr(Backbone.ModelBinding.radioAttr);
         if (!foundElements[group_name]) {
           foundElements[group_name] = true;
           Backbone.ModelBinding.HelperMethods.bidirectionalRadioGroupBinding.call(view, group_name, model);
@@ -82,7 +85,7 @@ Backbone.ModelBinding.Conventions = (function(){
       var self = this;
       view.$(selector).each(function(index){
         var element = view.$(this);
-        var field = element.attr('id');
+        var field = element.attr(Backbone.ModelBinding.attr);
         Backbone.ModelBinding.HelperMethods.bidirectionalCheckboxBinding.call(view, field, element, model);
       });
     }

--- a/spec/javascripts/conventionBindings.spec.js
+++ b/spec/javascripts/conventionBindings.spec.js
@@ -5,10 +5,44 @@ describe("conventionBindings", function(){
       education: "graduate", 
       graduated: "maybe",
       drivers_license: true,
+	  super_power: "mega pooping",
       bio: "my baby girl"
     });
     this.view = new AView({model: this.model});
     this.view.render();
+  });
+
+  describe("text element binding using configurable attribute", function(){
+	beforeEach(function(){
+		this.model = new AModel({
+			super_power: "mega pooping"
+		});
+		this.view = new AnotherView({model: this.model});
+		this.view.render();
+	});
+	
+	afterEach(function(){
+	  Backbone.ModelBinding.attr = 'id';
+	});
+	
+    it("bind view changes to the model's field, by configurable convention", function(){
+	  var el = this.view.$(".super_power");
+      el.val("x ray vision");
+      el.trigger('change');
+
+      expect(this.model.get('super_power')).toEqual("x ray vision");
+    });
+
+    it("bind model field changes to the form input, by convention of id", function(){
+	  this.model.set({super_power: "eating raw vegetables"});
+      var el = this.view.$(".super_power");
+      expect(el.val()).toEqual("eating raw vegetables");
+    });
+
+    it("binds the model's value to the form field on render", function(){
+	  var el = this.view.$(".super_power");
+      expect(el.val()).toEqual("mega pooping");
+    });
   });
 
   describe("text element binding", function(){

--- a/spec/javascripts/conventionBindings.spec.js
+++ b/spec/javascripts/conventionBindings.spec.js
@@ -5,7 +5,6 @@ describe("conventionBindings", function(){
       education: "graduate", 
       graduated: "maybe",
       drivers_license: true,
-	  super_power: "mega pooping",
       bio: "my baby girl"
     });
     this.view = new AView({model: this.model});
@@ -21,9 +20,9 @@ describe("conventionBindings", function(){
 		this.view.render();
 	});
 	
-	afterEach(function(){
-	  Backbone.ModelBinding.attr = 'id';
-	});
+	// afterEach(function(){
+	  // Backbone.ModelBinding.standardAttr = 'id';
+	// });
 	
     it("bind view changes to the model's field, by configurable convention", function(){
 	  var el = this.view.$(".super_power");

--- a/spec/javascripts/helpers/sample.backbone.app.js
+++ b/spec/javascripts/helpers/sample.backbone.app.js
@@ -14,7 +14,6 @@ AView = Backbone.View.extend({
       <input type='text' id='something'> \
       <div id='showIt'></div>\
       <input type='text' id='name'>\
-      <input type='text' class='super_power'>\
       <select id='education'> \
         <option value='high school'>high school</option> \
         <option value='college'>college</option> \
@@ -46,7 +45,6 @@ AnotherView = Backbone.View.extend({
       <input type='text' class='super_power'>\
     ");
     this.$(this.el).append(html);
-    Backbone.ModelBinding.attr = 'class';
-	Backbone.ModelBinding.call(this);
+	Backbone.ModelBinding.call(this, {standardAttribute: 'class'});
   },
 });

--- a/spec/javascripts/helpers/sample.backbone.app.js
+++ b/spec/javascripts/helpers/sample.backbone.app.js
@@ -14,6 +14,7 @@ AView = Backbone.View.extend({
       <input type='text' id='something'> \
       <div id='showIt'></div>\
       <input type='text' id='name'>\
+      <input type='text' class='super_power'>\
       <select id='education'> \
         <option value='high school'>high school</option> \
         <option value='college'>college</option> \
@@ -28,5 +29,24 @@ AView = Backbone.View.extend({
     ");
     this.$(this.el).append(html);
     Backbone.ModelBinding.call(this);
+  },
+});
+
+AnotherView = Backbone.View.extend({
+  formBindings: {
+    "#something": "a_field"
+  },
+
+  htmlBindings: {
+    "#showIt": "a_field"
+  },
+
+  render: function(){
+    var html = $("\
+      <input type='text' class='super_power'>\
+    ");
+    this.$(this.el).append(html);
+    Backbone.ModelBinding.attr = 'class';
+	Backbone.ModelBinding.call(this);
   },
 });


### PR DESCRIPTION
instead of forcing the usage of id, user can choose a different attribute (Backbone.ModelBinding.attr) for standard binding or for radio elements (Backbone.ModelBinding.radioAttr); by default these stay 'id' & 'name'.
