### PR TITLE
Documentation and globals fix

### DIFF
--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -169,7 +169,7 @@ Backbone.ModelBinding.Conventions = (function(){
 // Bi-Directional Binding Methods
 // ----------------------------
 Backbone.ModelBinding.Binders = (function(){
-  methods = {};
+  var methods = {};
 
   methods.bidirectionalBinding = function(attribute_name, element, model){
     var self = this;
@@ -181,7 +181,7 @@ Backbone.ModelBinding.Binders = (function(){
 
     // bind the form changes to the model
     element.bind("change", function(ev){
-      data = {};
+      var data = {};
       data[attribute_name] = self.$(ev.target).val();
       model.set(data);
     });

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ SomeView = Backbone.View.extend({
     // ... render your form here
 
     // execute the defined bindings
-    Backbone.ModelBindings.call(this);
+    Backbone.ModelBinding.call(this);
   }
 });
 ````
@@ -54,7 +54,7 @@ SomeView = Backbone.View.extend({
 Automatic bi-directional binding between your form input and your model. 
 
 The convention based binding requires no additional configuration or code in your
-view, other than calling the `Backbone.Modelbindings.call(this);` as noted above.
+view, other than calling the `Backbone.ModelBinding.call(this);` as noted above.
 With the conventions binding, your `<input>` fields will be bound to the views model
 by the id of the input. 
 
@@ -74,7 +74,7 @@ SomeView = Backbone.View.extend({
     // ... render your form here
 
     // execute the defined bindings
-    Backbone.ModelBindings.call(this);
+    Backbone.ModelBinding.call(this);
   }
 });
 


### PR DESCRIPTION
Hi Derick,

Nice plug-in!

A couple of questions/suggestions:

Documentation says to call: Backbone.ModelBindings.call(this); this should probably be Backbone.ModelBinding.call(this); ?

Also this plug-in creates two global variables, I'm assuming this is a mistake? At least it seems to work when scoping them.

Cheers
Øyvind
