### PR TITLE
Checkbox's initial state is set incorrectly & diplay:none / display:block bindings

### DIFF
--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -395,6 +395,12 @@ Backbone.ModelBinding.DataBindBinding = (function(){
       case "enabled":
         element.attr("disabled", !val);
         break;
+      case "displayed":
+        element.css("display", val ? 'block' : 'none' );
+        break;
+      case "hidden":
+        element.css("display", val ? 'none' : 'block' );
+        break;
       default:
         element.attr(attr, val);
     }

--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -328,7 +328,7 @@ Backbone.ModelBinding.CheckboxBinding = (function(){
       var attr_exists = model.attributes.hasOwnProperty(attribute_name);
       if (attr_exists) {
         var attr_value = model.get(attribute_name);
-        if (typeof attr_value !== "undefined" && attr_value !== null) {
+        if (typeof attr_value !== "undefined" && attr_value !== null && attr_value !== false) {
           element.attr("checked", "checked");
         }
         else{


### PR DESCRIPTION
There's a small bug when setting the initial state, that sets the checkbox checked even for false values. I've attached a small fix.

Also attached is a simple new feature that lets binding booleans to the visibility of the bound element.
