### PR TITLE
Typo for textarea when setting all binding attributes

### DIFF
--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -79,7 +79,7 @@ Backbone.ModelBinding.Configuration = (function(){
     configureAllBindingAttributes: function(attribute){
       this.storeBindingAttrConfig();
       bindingAttrConfig.text = attribute;
-      bindingAttrConfig.texarea = attribute;
+      bindingAttrConfig.textarea = attribute;
       bindingAttrConfig.password = attribute;
       bindingAttrConfig.radio = attribute;
       bindingAttrConfig.checkbox = attribute;

--- a/spec/javascripts/configureAllBindingAttributes.spec.js
+++ b/spec/javascripts/configureAllBindingAttributes.spec.js
@@ -2,6 +2,7 @@ describe("configure all binding attributes", function(){
   beforeEach(function(){
     this.model = new AModel({
       name: "some dude",
+      bio: "not much",
       education: "graduate",
       graduated: "maybe",
       drivers_license: true
@@ -33,6 +34,27 @@ describe("configure all binding attributes", function(){
     it("binds the model's value to the form field on render", function(){
       var el = this.view.$("#v_name");
       expect(el.val()).toEqual("some dude");
+    });
+  });
+  
+  describe("textarea element binding using configurable attribute", function(){
+    it("bind view changes to the model's field, by configurable convention", function(){
+      var el = this.view.$("#v_bio");
+      el.val("biography");
+      el.trigger('change');
+
+      expect(this.model.get('bio')).toEqual("biography");
+    });
+
+    it("bind model field changes to the form input, by convention of id", function(){
+      this.model.set({bio: "biography, schmiography"});
+      var el = this.view.$("#v_bio");
+      expect(el.val()).toEqual("biography, schmiography");
+    });
+
+    it("binds the model's value to the form field on render", function(){
+      var el = this.view.$("#v_bio");
+      expect(el.val()).toEqual("not much");
     });
   });
   


### PR DESCRIPTION
When doing this;

``` javascript
Backbone.ModelBinding.bind(this, { all: 'class' });
```

There is a typo in Backbone.ModelBinding.Configuration that attempts to set the binding attribute on "texarea" instead of "textarea". This commit fixes this.

I also noticed that textareas weren't tested in the specs like the other field types were, even though a textarea field exists in the view - so I added that while I was at it.
