### PR TITLE
Fix for IE related bug, missing trim method on Strings

### DIFF
--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -415,7 +415,7 @@ Backbone.ModelBinding.DataBindBinding = (function(){
     var dataBindConfigList = [];
     var databindList = element.attr("data-bind").split(";");
     _.each(databindList, function(attrbind){
-      var databind = attrbind.trim().split(" ");
+      var databind = $.trim(attrbind).split(" ");
 
       // make the default special case "text" if none specified
       if( databind.length == 1 ) databind.unshift("text");


### PR DESCRIPTION
Fix IE bug, IE doesn't have trim method on Strings http://stackoverflow.com/questions/2308134/trim-in-javascript-not-working-in-ie
