### PR TITLE
Fix to SelectBoxBinding

### DIFF
--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -213,6 +213,12 @@ Backbone.ModelBinding.SelectBoxBinding = (function(){
       var attr_value = model.get(attribute_name);
       if (typeof attr_value !== "undefined" && attr_value !== null) {
         element.val(attr_value);
+
+        if (element.val() != attr_value) {
+          var data = {};
+          data[attribute_name] = element.val();
+          model.set(data);
+        }
       }
     });
   };

--- a/readme.md
+++ b/readme.md
@@ -299,13 +299,13 @@ someModel.set({isValid: false});
 This will disable the button when the model is invalid and enable the button when the model is
 valid.
 
-#### display
+#### displayed
 
 This allows you to specify that an element should be shown or hidden by setting the css
 of the element according to the value of the model properties specified.
 
 ````
-<div data-bind="display isValid" />
+<div data-bind="displayed isValid" />
 
 someModel.set({isValid: false});
 ````
@@ -316,7 +316,7 @@ will be set to `block`.
 
 #### hidden
 
-This is the inverse of `display`.
+This is the inverse of `displayed`.
 
 ````
 <div data-bind="hidden isValid" />
@@ -556,7 +556,7 @@ to Backbone.ModelBinding in the `backbone.modelbinding.js` file.
 ### v0.3.3
 
 * Added data-bind attribute for setting an HTML element's `display` css
-* Added inserve of data-bind `display` as data-bind `hidden`
+* Added inserve of data-bind `displayed` as data-bind `hidden`
 * Corrected issue with binding a model's property to a checkbox, when the property is false
 
 ### v0.3.2


### PR DESCRIPTION
If I have a select:

&lt;select id="myValue"&gt;
   &lt;option value="1"&gt;1&lt;/option&gt;
   &lt;option value="2"&gt;2&lt;/option&gt;
&lt;/select&gt;

and a model where myValue = 3, then binding the two leaves the select on its current value, and the model with myValue still set to 3.  This patch detects that the select did not update correctly, and so pushes the current value of the select back to the model to ensure that the two are in sync.

Also have a minor fix to the readme re: the "displayed" data binding attribute.
