### PR TITLE
Add configuration to handle prefix on attribute's values

### DIFF
--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -64,6 +64,8 @@ Backbone.ModelBinding.Configuration = (function(_){
 	  select: "id"
   };
 
+  var bindingAttrsNamePrefix = "";
+
   return {
     configureBindingAttributes: function(options){
       if (options) {
@@ -86,6 +88,11 @@ Backbone.ModelBinding.Configuration = (function(_){
       bindingAttrConfig.select = attribute;
     },
 
+    configureBindingAttributesNamePrefix: function(prefix){
+      this.storeBindingAttrConfig();
+      bindingAttrsNamePrefix = prefix;
+    },
+
     storeBindingAttrConfig: function(){
       this._config = _.clone(bindingAttrConfig);
     },
@@ -101,7 +108,9 @@ Backbone.ModelBinding.Configuration = (function(_){
 
     getBindingValue: function(element, type){
       var bindingAttr = this.getBindingAttr(type);
-      return element.attr(bindingAttr);
+        var attrValue = element.attr(bindingAttr);
+        attrValue = attrValue.substring(bindingAttrsNamePrefix.length, attrValue.length);
+        return attrValue;
     }
   };
 })(_);

--- a/readme.md
+++ b/readme.md
@@ -460,6 +460,17 @@ Backbone.ModelBinding.Configuration.configureBindingAttributes({text: "modelAttr
 
 Now all text boxes will update the model property specified in the text box's `modelAttr`.
 
+### Remove Prefix on All Element Binding Attributes
+
+The following will remove `prefixAttr` on all attribute's values:
+
+````
+Backbone.ModelBinding.Configuration.configureBindingAttributesNamePrefix("prefixAttr");
+````
+
+This is usefull when your HTML form elements use your model attribute's names plus a prefix.
+Useful if you will have multiple forms on the same page.
+
 ## Pluggable Conventions
 
 The convention based bindings are pluggable. Each of the existing form input types can have it's


### PR DESCRIPTION
Hi,

To avoid ids collision, I added a prefix on my model attributes to build my html forms.
So when in my model, there is a `name` attribute, the matching html element has a id equals to `prefix-name` (assuming that `prefix-` is my prefix).

That's why I modified the function getBindingValue in the Configuration object to take into account a prefix (if defined).

Thanks
