### PR TITLE
Adding some new HTML5 input conventions number, range, tel, search, url, 

### DIFF
--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -463,7 +463,7 @@ Backbone.ModelBinding = (function(Backbone, _, $){
     number: {selector: "input[type=number]", handler: StandardBinding},
     range: {selector: "input[type=range]", handler: StandardBinding},
     tel: {selector: "input[type=tel]", handler: StandardBinding},
-    search: {selector: "input[type=seacrh]", handler: StandardBinding},
+    search: {selector: "input[type=search]", handler: StandardBinding},
     url: {selector: "input[type=url]", handler: StandardBinding},
     email: {selector: "input[type=email]", handler: StandardBinding}
   };

--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -107,7 +107,14 @@ Backbone.ModelBinding = (function(Backbone, _, $){
     password: "id",
     radio: "name",
     checkbox: "id",
-    select: "id"
+    select: "id",
+    number: "id",
+    range: "id",
+    tel: "id",
+    search: "id",
+    url: "id",
+    email: "id"
+
   };
 
   modelBinding.Configuration.store = function(){
@@ -134,6 +141,12 @@ Backbone.ModelBinding = (function(Backbone, _, $){
     config.radio = attribute;
     config.checkbox = attribute;
     config.select = attribute;
+    config.number = attribute;
+    config.range = attribute;
+    config.tel = attribute;
+    config.search = attribute;
+    config.url = attribute;
+    config.email = attribute;
   };
 
   // ----------------------------
@@ -445,7 +458,14 @@ Backbone.ModelBinding = (function(Backbone, _, $){
     radio: {selector: "input:radio", handler: RadioGroupBinding},
     checkbox: {selector: "input:checkbox", handler: CheckboxBinding},
     select: {selector: "select", handler: SelectBoxBinding},
-    databind: { selector: "*[data-bind]", handler: DataBindBinding}
+    databind: { selector: "*[data-bind]", handler: DataBindBinding},
+    // HTML5 input
+    number: {selector: "input[type=number]", handler: StandardBinding},
+    range: {selector: "input[type=range]", handler: StandardBinding},
+    tel: {selector: "input[type=tel]", handler: StandardBinding},
+    search: {selector: "input[type=seacrh]", handler: StandardBinding},
+    url: {selector: "input[type=url]", handler: StandardBinding},
+    email: {selector: "input[type=email]", handler: StandardBinding}
   };
 
   return modelBinding;

--- a/readme.md
+++ b/readme.md
@@ -388,6 +388,14 @@ The following form input types are supported by the form convention binder:
 * select 
 * radio button groups
 
+HTML5
+* number
+* range
+* email
+* url
+* tel
+* search
+
 Radio buttons are group are assumed to be grouped by the `name` attribute of the 
 radio button items. 
 

--- a/spec/javascripts/helpers/sample.backbone.app.js
+++ b/spec/javascripts/helpers/sample.backbone.app.js
@@ -46,7 +46,13 @@ AView = Backbone.View.extend({
       <textarea id='bio'></textarea>\
       <p id='aParagraph'></p>\
       <input type='password' id='password'>\
-    ");
+      <input type='number' id='number'>\
+      <input type='range' id='range' min='0' max='98765'>\
+      <input type='email' id='email'>\
+      <input type='url' id='url'>\
+      <input type='tel' id='tel'>\
+      <input type='search' id='search'>\
+      ");
     this.$(this.el).append(html);
     Backbone.ModelBinding.bind(this);
   }

--- a/spec/javascripts/html5inputConventionBinding.spec.js
+++ b/spec/javascripts/html5inputConventionBinding.spec.js
@@ -36,10 +36,10 @@ describe("textbox convention bindings", function(){
   describe("range element binding", function(){
     it("bind view changes to the model's field, by convention of id", function(){
       var el = this.view.$("#range");
-      el.val("09876");
+      el.val("9876");
       el.trigger('change');
 
-      expect(this.model.get('range')).toEqual("09876");
+      expect(this.model.get('range')).toEqual("9876");
     });
 
     it("bind model field changes to the form input, by convention of id", function(){
@@ -50,7 +50,7 @@ describe("textbox convention bindings", function(){
 
     it("binds the model's value to the form field on render", function(){
       var el = this.view.$("#range");
-      expect(el.val()).toEqual("1234");
+      expect(el.val()).toEqual("65");
     });
   });
 
@@ -74,7 +74,7 @@ describe("textbox convention bindings", function(){
       expect(el.val()).toEqual("321-123-1222");
     });
   });
-
+    
    describe("search element binding", function(){
     it("bind view changes to the model's field, by convention of id", function(){
       var el = this.view.$("#search");

--- a/spec/javascripts/html5inputConventionBinding.spec.js
+++ b/spec/javascripts/html5inputConventionBinding.spec.js
@@ -1,0 +1,142 @@
+describe("textbox convention bindings", function(){
+  beforeEach(function(){
+    this.model = new AModel({
+        number: "1234",
+        range: "65",
+        tel: "321-123-1222",
+        search: "search text",
+        url: "http:\\\\url.com",
+        email: "email@domain.com"
+    });
+    this.view = new AView({model: this.model});
+    this.view.render();
+  });
+
+  describe("number element binding", function(){
+    it("bind view changes to the model's field, by convention of id", function(){
+      var el = this.view.$("#number");
+      el.val("09876");
+      el.trigger('change');
+
+      expect(this.model.get('number')).toEqual("09876");
+    });
+
+    it("bind model field changes to the form input, by convention of id", function(){
+      this.model.set({number: "45678"});
+      var el = this.view.$("#number");
+      expect(el.val()).toEqual("45678");
+    });
+
+    it("binds the model's value to the form field on render", function(){
+      var el = this.view.$("#number");
+      expect(el.val()).toEqual("1234");
+    });
+  });
+
+  describe("range element binding", function(){
+    it("bind view changes to the model's field, by convention of id", function(){
+      var el = this.view.$("#range");
+      el.val("09876");
+      el.trigger('change');
+
+      expect(this.model.get('range')).toEqual("09876");
+    });
+
+    it("bind model field changes to the form input, by convention of id", function(){
+      this.model.set({range: "45678"});
+      var el = this.view.$("#range");
+      expect(el.val()).toEqual("45678");
+    });
+
+    it("binds the model's value to the form field on render", function(){
+      var el = this.view.$("#range");
+      expect(el.val()).toEqual("1234");
+    });
+  });
+
+   describe("tel element binding", function(){
+    it("bind view changes to the model's field, by convention of id", function(){
+      var el = this.view.$("#tel");
+      el.val("321-345-5555");
+      el.trigger('change');
+
+      expect(this.model.get('tel')).toEqual("321-345-5555");
+    });
+
+    it("bind model field changes to the form input, by convention of id", function(){
+      this.model.set({tel: "456-345-5555"});
+      var el = this.view.$("#tel");
+      expect(el.val()).toEqual("456-345-5555");
+    });
+
+    it("binds the model's value to the form field on render", function(){
+      var el = this.view.$("#tel");
+      expect(el.val()).toEqual("321-123-1222");
+    });
+  });
+
+   describe("search element binding", function(){
+    it("bind view changes to the model's field, by convention of id", function(){
+      var el = this.view.$("#search");
+      el.val("more text");
+      el.trigger('change');
+
+      expect(this.model.get('search')).toEqual("more text");
+    });
+
+    it("bind model field changes to the form input, by convention of id", function(){
+      this.model.set({search: "new text"});
+      var el = this.view.$("#search");
+      expect(el.val()).toEqual("new text");
+    });
+
+    it("binds the model's value to the form field on render", function(){
+      var el = this.view.$("#search");
+      expect(el.val()).toEqual("search text");
+    });
+  });
+
+   describe("url element binding", function(){
+    it("bind view changes to the model's field, by convention of id", function(){
+      var el = this.view.$("#url");
+      el.val("some url");
+      el.trigger('change');
+
+      expect(this.model.get('url')).toEqual("some url");
+    });
+
+    it("bind model field changes to the form input, by convention of id", function(){
+      this.model.set({url: "new url"});
+      var el = this.view.$("#url");
+      expect(el.val()).toEqual("new url");
+    });
+
+    it("binds the model's value to the form field on render", function(){
+      var el = this.view.$("#url");
+      expect(el.val()).toEqual("http:\\\\url.com");
+    });
+  });
+
+  describe("email element binding", function(){
+    it("bind view changes to the model's field, by convention of id", function(){
+      var el = this.view.$("#email");
+      el.val("new@email.com");
+      el.trigger('change');
+        
+      expect(this.model.get('email')).toEqual("new@email.com");
+    });
+
+    it("bind model field changes to the form input, by convention of id", function(){
+      this.model.set({email: "more@email.gov"});
+      var el = this.view.$("#email");
+      expect(el.val()).toEqual("more@email.gov");
+    });
+
+    it("binds the model's value to the form field on render", function(){
+      var el = this.view.$("#email");
+      expect(el.val()).toEqual("email@domain.com");
+    });
+  });
+
+
+});


### PR DESCRIPTION
Derick,

I added only the input types in HTML5 that are corresponding to the text type. For range min and max an additional binding is needed. I am still setting up my system to run the tests. I added them, but have not been able to run them yet. 

Mikhail
