### PR TITLE
Fix the value_selector in RadioGroupBinding to quote the "val"

### DIFF
--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -274,7 +274,7 @@ Backbone.ModelBinding = (function(Backbone, _, $){
           var bindingAttr = config.getBindingAttr('radio');
 
           var modelChange = function(model, val){
-            var value_selector = "input[type=radio][" + bindingAttr + "=" + group_name + "][value=" + val + "]";
+            var value_selector = "input[type=radio][" + bindingAttr + "=" + group_name + "][value='" + val + "']";
             view.$(value_selector).attr("checked", "checked");
           };
           modelBinder.registerModelBinding(model, group_name, modelChange);


### PR DESCRIPTION
Fix the value_selector in RadioGroupBinding to quote the "val" in the value= selector. This resolves an issue where values have characters that the selector engine doesn't like unquoted (e.g. "Foo/bar").
