### PR TITLE
Add support to _text attributes of multi-select boxes

### DIFF
--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -238,7 +238,12 @@ var modelbinding = (function(Backbone, _, $) {
         var elementChange = function(ev){
           var targetEl = view.$(ev.target);
           var value = targetEl.val();
-          var text = targetEl.find(":selected").text();
+          var selections = targetEl.find(":selected");
+          if (selections.size() > 1) {
+            var text = _.map(selections, function(sel){ return sel.text });
+          } else {
+            var text = selections.text();
+          }
           setModelValue(attribute_name, value, text);
         };
 

--- a/spec/javascripts/helpers/sample.backbone.app.js
+++ b/spec/javascripts/helpers/sample.backbone.app.js
@@ -42,6 +42,10 @@ AView = Backbone.View.extend({
         <option value='pre_selected' selected='selected'>pre selected</option> \
         <option value='not_selected'>not selected</option> \
       </select> \
+      <select id='multiple_select' multiple='true'> \
+        <option value='selection_1'>Selection 1</option> \
+        <option value='selection_2'>Selection 2</option> \
+      </select> \
       <input type='radio' id='graduated_yes' name='graduated' value='yes'>\
       <input type='radio' id='graduated_no' name='graduated' value='no'>\
       <input type='radio' id='graduated_maybe' name='graduated' value='maybe'>\

--- a/spec/javascripts/selectboxConventionBindings.spec.js
+++ b/spec/javascripts/selectboxConventionBindings.spec.js
@@ -46,6 +46,14 @@ describe("select element convention binding", function(){
 
     expect(this.model.get('education_text')).toEqual("i dun learned at grade skool");
   });
+  
+  it("applies the text of multiple selections to the model", function(){
+    var el = this.view.$("#multiple_select");
+    el.val(["selection_1", "selection_2"]);
+    el.trigger('change');
+
+    expect(this.model.get('multiple_select_text')).toEqual(["Selection 1", "Selection 2"]);
+  });
 
   it("updates the model to the selected value when the model is set to a value that doesn't exist, on render", function(){
     var el = this.view.$("#operating_system");


### PR DESCRIPTION
The title (and commit message) kind of speak for themselves.  I have some multi-select boxes, and without this patch, the "_text" attribute is pretty useless.

For example, with the view:

``` html
      <select id='multiple_select' multiple='true'>
        <option value='selection_1'>Selection 1</option>
        <option value='selection_2'>Selection 2</option>
      </select>
```

with both of these selected you'll have an attribute like:

``` javascript
model.multiple_select
 -> ["selection_1", "selection_2"]
model.multiple_select_text
 -> "Selection 1Selection 2"
```

With my patch, things will work more appropriately:

``` javascript
model.multiple_select
 -> ["selection_1", "selection_2"]
model.multiple_select_text
 -> ["Selection 1", "Selection 2"]
```

Hooray!

Specs are included, let me know what you think!
