### PR TITLE
Update to Support Zepto and updated specs

### DIFF
--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -176,13 +176,14 @@ var modelbinding = (function(Backbone, _, $) {
 
     methods.bind = function(selector, view, model, config){
       var modelBinder = this;
-
       view.$(selector).each(function(index){
         var element = view.$(this);
         var elementType = _getElementType(element);
         var attribute_name = config.getBindingValue(element, elementType);
 
-        var modelChange = function(changed_model, val){ element.val(val); };
+        var modelChange = function(changed_model, val){
+          element.val(val);
+        };
 
         var setModelValue = function(attr_name, value){
           var data = {};
@@ -221,12 +222,14 @@ var modelbinding = (function(Backbone, _, $) {
 
     methods.bind = function(selector, view, model, config){
       var modelBinder = this;
-
+      var self = this;
       view.$(selector).each(function(index){
-        var element = view.$(this);
+        var element = $(this);
         var attribute_name = config.getBindingValue(element, 'select');
 
-        var modelChange = function(changed_model, val){ element.val(val); };
+        var modelChange = function(changed_model, val){
+          element.val(val);
+        };
 
         var setModelValue = function(attr, val, text){
           var data = {};
@@ -236,9 +239,10 @@ var modelbinding = (function(Backbone, _, $) {
         };
 
         var elementChange = function(ev){
-          var targetEl = view.$(ev.target);
+
+          var targetEl = $(ev.target);
           var value = targetEl.val();
-          var text = targetEl.find(":selected").text();
+          var text = targetEl.find("option[value=\"" + value +"\"]").text();
           setModelValue(attribute_name, value, text);
         };
 
@@ -254,7 +258,7 @@ var modelbinding = (function(Backbone, _, $) {
         // set the model to the form's value if there is no model value
         if (element.val() != attr_value) {
           var value = element.val();
-          var text = element.find(":selected").text();
+          var text = element.find("option[selected]").text();
           setModelValue(attribute_name, value, text);
         }
       });
@@ -511,11 +515,11 @@ var modelbinding = (function(Backbone, _, $) {
   // Binding Conventions
   // ----------------------------
   modelBinding.Conventions = {
-    text: {selector: "input:text", handler: StandardBinding},
+    text: {selector: window.Zepto == undefined ? "input:text" : "input[type='text']", handler: StandardBinding},
     textarea: {selector: "textarea", handler: StandardBinding},
-    password: {selector: "input:password", handler: StandardBinding},
-    radio: {selector: "input:radio", handler: RadioGroupBinding},
-    checkbox: {selector: "input:checkbox", handler: CheckboxBinding},
+    password: {selector: "input[type='password']", handler: StandardBinding},
+    radio: {selector: "input[type='radio']", handler: RadioGroupBinding},
+    checkbox: {selector: "input[type='checkbox']", handler: CheckboxBinding},
     select: {selector: "select", handler: SelectBoxBinding},
     databind: { selector: "*[data-bind]", handler: DataBindBinding},
     // HTML5 input

--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -176,8 +176,8 @@ var modelbinding = (function(Backbone, _, $) {
 
     methods.bind = function(selector, view, model, config){
       var modelBinder = this;
-      view.$(selector).each(function(index){
-        var element = view.$(this);
+      $(view.el).find(selector).each(function(index){
+        var element = $(this);
         var elementType = _getElementType(element);
         var attribute_name = config.getBindingValue(element, elementType);
 
@@ -192,7 +192,7 @@ var modelbinding = (function(Backbone, _, $) {
         };
 
         var elementChange = function(ev){
-          setModelValue(attribute_name, view.$(ev.target).val());
+          setModelValue(attribute_name, $(ev.target).val());
         };
 
         modelBinder.registerModelBinding(model, attribute_name, modelChange);
@@ -223,7 +223,7 @@ var modelbinding = (function(Backbone, _, $) {
     methods.bind = function(selector, view, model, config){
       var modelBinder = this;
       var self = this;
-      view.$(selector).each(function(index){
+      $(view.el).find(selector).each(function(index){
         var element = $(this);
         var attribute_name = config.getBindingValue(element, 'select');
 
@@ -277,8 +277,8 @@ var modelbinding = (function(Backbone, _, $) {
       var modelBinder = this;
 
       var foundElements = [];
-      view.$(selector).each(function(index){
-        var element = view.$(this);
+      $(view.el).find(selector).each(function(index){
+        var element = $(this);
 
         var group_name = config.getBindingValue(element, 'radio');
         if (!foundElements[group_name]) {
@@ -287,7 +287,7 @@ var modelbinding = (function(Backbone, _, $) {
 
           var modelChange = function(model, val){
             var value_selector = "input[type=radio][" + bindingAttr + "=" + group_name + "][value='" + val + "']";
-            view.$(value_selector).attr("checked", "checked");
+            $(view.el).find(value_selector).attr("checked", "checked");
           };
           modelBinder.registerModelBinding(model, group_name, modelChange);
 
@@ -299,14 +299,14 @@ var modelbinding = (function(Backbone, _, $) {
 
           // bind the form changes to the model
           var elementChange = function(ev){
-            var element = view.$(ev.currentTarget);
+            var element = $(ev.currentTarget);
             if (element.is(":checked")){
               setModelValue(group_name, element.val());
             }
           };
 
           var group_selector = "input[type=radio][" + bindingAttr + "=" + group_name + "]";
-          view.$(group_selector).each(function(){
+          $(view.el).find(group_selector).each(function(){
             var groupEl = $(this);
             modelBinder.registerElementBinding(groupEl, elementChange);
           });
@@ -315,11 +315,11 @@ var modelbinding = (function(Backbone, _, $) {
           if (typeof attr_value !== "undefined" && attr_value !== null) {
             // set the default value on the form, from the model
             var value_selector = "input[type=radio][" + bindingAttr + "=" + group_name + "][value='" + attr_value + "']";
-            view.$(value_selector).attr("checked", "checked");
+            $(view.el).find(value_selector).attr("checked", "checked");
           } else {
             // set the model to the currently selected radio button
             var value_selector = "input[type=radio][" + bindingAttr + "=" + group_name + "]:checked";
-            var value = view.$(value_selector).val();
+            var value = $(view.el).find(value_selector).val();
             setModelValue(group_name, value);
           }
         }
@@ -338,8 +338,8 @@ var modelbinding = (function(Backbone, _, $) {
     methods.bind = function(selector, view, model, config){
       var modelBinder = this;
 
-      view.$(selector).each(function(index){
-        var element = view.$(this);
+      $(view.el).find(selector).each(function(index){
+        var element = $(this);
         var bindingAttr = config.getBindingAttr('checkbox');
         var attribute_name = config.getBindingValue(element, 'checkbox');
 
@@ -359,7 +359,7 @@ var modelbinding = (function(Backbone, _, $) {
         };
 
         var elementChange = function(ev){
-          var changedElement = view.$(ev.target);
+          var changedElement = $(ev.target);
           var checked = changedElement.is(":checked")? true : false;
           setModelValue(attribute_name, checked);
         };
@@ -453,8 +453,13 @@ var modelbinding = (function(Backbone, _, $) {
       var dataBindConfigList = [];
       var dataBindAttributeName = modelBinding.Conventions.databind.selector.replace(/^(.*\[)([^\]]*)(].*)/g, '$2');
       var databindList = element.attr(dataBindAttributeName).split(";");
-      _.each(databindList, function(attrbind){
-        var databind = $.trim(attrbind).split(" ");
+      _.each(databindList, function(attrbind) {
+        var databind;
+        if ( window.Zepto != undefined ) {
+          databind = $('<div></div>').text(attrbind).text().trim(attrbind).split(" ");
+        } else {
+          databind = $.trim(attrbind).split(" ");
+        }
 
         // make the default special case "text" if none specified
         if( databind.length == 1 ) databind.unshift("text");
@@ -493,8 +498,8 @@ var modelbinding = (function(Backbone, _, $) {
     methods.bind = function(selector, view, model, config){
       var modelBinder = this;
 
-      view.$(selector).each(function(index){
-        var element = view.$(this);
+      $(view.el).find(selector).each(function(index){
+        var element = $(this);
         var databindList = splitBindingAttr(element);
 
         _.each(databindList, function(databind){

--- a/public/javascripts/zepto.js
+++ b/public/javascripts/zepto.js
@@ -1,0 +1,1413 @@
+//     Zepto.js
+//     (c) 2010, 2011 Thomas Fuchs
+//     Zepto.js may be freely distributed under the MIT license.
+
+(function(undefined){
+  if (String.prototype.trim === undefined) // fix for iOS 3.2
+    String.prototype.trim = function(){ return this.replace(/^\s+/, '').replace(/\s+$/, '') };
+
+  // For iOS 3.x
+  // from https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/reduce
+  if (Array.prototype.reduce === undefined)
+    Array.prototype.reduce = function(fun){
+      if(this === void 0 || this === null) throw new TypeError();
+      var t = Object(this), len = t.length >>> 0, k = 0, accumulator;
+      if(typeof fun != 'function') throw new TypeError();
+      if(len == 0 && arguments.length == 1) throw new TypeError();
+
+      if(arguments.length >= 2)
+       accumulator = arguments[1];
+      else
+        do{
+          if(k in t){
+            accumulator = t[k++];
+            break;
+          }
+          if(++k >= len) throw new TypeError();
+        } while (true);
+
+      while (k < len){
+        if(k in t) accumulator = fun.call(undefined, accumulator, t[k], k, t);
+        k++;
+      }
+      return accumulator;
+    };
+
+})();
+//     Zepto.js
+//     (c) 2010, 2011 Thomas Fuchs
+//     Zepto.js may be freely distributed under the MIT license.
+
+var Zepto = (function() {
+  var undefined, key, $$, classList, emptyArray = [], slice = emptyArray.slice,
+    document = window.document,
+    elementDisplay = {}, classCache = {},
+    getComputedStyle = document.defaultView.getComputedStyle,
+    cssNumber = { 'column-count': 1, 'columns': 1, 'font-weight': 1, 'line-height': 1,'opacity': 1, 'z-index': 1, 'zoom': 1 },
+    fragmentRE = /^\s*<(\w+)[^>]*>/,
+    elementTypes = [1, 9, 11],
+    adjacencyOperators = [ 'after', 'prepend', 'before', 'append' ],
+    table = document.createElement('table'),
+    tableRow = document.createElement('tr'),
+    containers = {
+      'tr': document.createElement('tbody'),
+      'tbody': table, 'thead': table, 'tfoot': table,
+      'td': tableRow, 'th': tableRow,
+      '*': document.createElement('div')
+    },
+    readyRE = /complete|loaded|interactive/,
+    classSelectorRE = /^\.([\w-]+)$/,
+    idSelectorRE = /^#([\w-]+)$/,
+    tagSelectorRE = /^[\w-]+$/;
+
+  function isF(value) { return ({}).toString.call(value) == "[object Function]" }
+  function isO(value) { return value instanceof Object }
+  function isA(value) { return value instanceof Array }
+  function likeArray(obj) { return typeof obj.length == 'number' }
+
+  function compact(array) { return array.filter(function(item){ return item !== undefined && item !== null }) }
+  function flatten(array) { return array.length > 0 ? [].concat.apply([], array) : array }
+  function camelize(str)  { return str.replace(/-+(.)?/g, function(match, chr){ return chr ? chr.toUpperCase() : '' }) }
+  function dasherize(str){
+    return str.replace(/::/g, '/')
+           .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+           .replace(/([a-z\d])([A-Z])/g, '$1_$2')
+           .replace(/_/g, '-')
+           .toLowerCase();
+  }
+  function uniq(array)    { return array.filter(function(item,index,array){ return array.indexOf(item) == index }) }
+
+  function classRE(name){
+    return name in classCache ?
+      classCache[name] : (classCache[name] = new RegExp('(^|\\s)' + name + '(\\s|$)'));
+  }
+
+  function maybeAddPx(name, value) { return (typeof value == "number" && !cssNumber[dasherize(name)]) ? value + "px" : value; }
+
+  function defaultDisplay(nodeName) {
+    var element, display;
+    if (!elementDisplay[nodeName]) {
+      element = document.createElement(nodeName);
+      document.body.appendChild(element);
+      display = getComputedStyle(element, '').getPropertyValue("display");
+      element.parentNode.removeChild(element);
+      display == "none" && (display = "block");
+      elementDisplay[nodeName] = display;
+    }
+    return elementDisplay[nodeName];
+  }
+
+  function fragment(html, name) {
+    if (name === undefined) fragmentRE.test(html) && RegExp.$1;
+    if (!(name in containers)) name = '*';
+    var container = containers[name];
+    container.innerHTML = '' + html;
+    return slice.call(container.childNodes);
+  }
+
+  function Z(dom, selector){
+    dom = dom || emptyArray;
+    dom.__proto__ = Z.prototype;
+    dom.selector = selector || '';
+    return dom;
+  }
+
+  function $(selector, context){
+    if (!selector) return Z();
+    if (context !== undefined) return $(context).find(selector);
+    else if (isF(selector)) return $(document).ready(selector);
+    else if (selector instanceof Z) return selector;
+    else {
+      var dom;
+      if (isA(selector)) dom = compact(selector);
+      else if (elementTypes.indexOf(selector.nodeType) >= 0 || selector === window)
+        dom = [selector], selector = null;
+      else if (fragmentRE.test(selector))
+        dom = fragment(selector.trim(), RegExp.$1), selector = null;
+      else if (selector.nodeType && selector.nodeType == 3) dom = [selector];
+      else dom = $$(document, selector);
+      return Z(dom, selector);
+    }
+  }
+
+  $.extend = function(target){
+    slice.call(arguments, 1).forEach(function(source) {
+      for (key in source) target[key] = source[key];
+    })
+    return target;
+  }
+
+  $.qsa = $$ = function(element, selector){
+    var found;
+    return (element === document && idSelectorRE.test(selector)) ?
+      ( (found = element.getElementById(RegExp.$1)) ? [found] : emptyArray ) :
+      slice.call(
+        classSelectorRE.test(selector) ? element.getElementsByClassName(RegExp.$1) :
+        tagSelectorRE.test(selector) ? element.getElementsByTagName(selector) :
+        element.querySelectorAll(selector)
+      );
+  }
+
+  function filtered(nodes, selector){
+    return selector === undefined ? $(nodes) : $(nodes).filter(selector);
+  }
+
+  function funcArg(context, arg, idx, payload){
+   return isF(arg) ? arg.call(context, idx, payload) : arg;
+  }
+
+  $.isFunction = isF;
+  $.isObject = isO;
+  $.isArray = isA;
+
+  $.map = function(elements, callback) {
+    var value, values = [], i, key;
+    if (likeArray(elements))
+      for (i = 0; i < elements.length; i++) {
+        value = callback(elements[i], i);
+        if (value != null) values.push(value);
+      }
+    else
+      for (key in elements) {
+        value = callback(elements[key], key);
+        if (value != null) values.push(value);
+      }
+    return flatten(values);
+  }
+
+  $.each = function(elements, callback) {
+    var i, key;
+    if (likeArray(elements))
+      for(i = 0; i < elements.length; i++) {
+        if(callback(i, elements[i]) === false) return elements;
+      }
+    else
+      for(key in elements) {
+        if(callback(key, elements[key]) === false) return elements;
+      }
+    return elements;
+  }
+
+  $.fn = {
+    forEach: emptyArray.forEach,
+    reduce: emptyArray.reduce,
+    push: emptyArray.push,
+    indexOf: emptyArray.indexOf,
+    concat: emptyArray.concat,
+    map: function(fn){
+      return $.map(this, function(el, i){ return fn.call(el, i, el) });
+    },
+    slice: function(){
+      return $(slice.apply(this, arguments));
+    },
+    ready: function(callback){
+      if (readyRE.test(document.readyState)) callback($);
+      else document.addEventListener('DOMContentLoaded', function(){ callback($) }, false);
+      return this;
+    },
+    get: function(idx){ return idx === undefined ? this : this[idx] },
+    size: function(){ return this.length },
+    remove: function () {
+      return this.each(function () {
+        if (this.parentNode != null) {
+          this.parentNode.removeChild(this);
+        }
+      });
+    },
+    each: function(callback){
+      this.forEach(function(el, idx){ callback.call(el, idx, el) });
+      return this;
+    },
+    filter: function(selector){
+      return $([].filter.call(this, function(element){
+        return element.parentNode && $$(element.parentNode, selector).indexOf(element) >= 0;
+      }));
+    },
+    end: function(){
+      return this.prevObject || $();
+    },
+    andSelf:function(){
+      return this.add(this.prevObject || $())
+    },
+    add:function(selector,context){
+      return $(uniq(this.concat($(selector,context))));
+    },
+    is: function(selector){
+      return this.length > 0 && $(this[0]).filter(selector).length > 0;
+    },
+    not: function(selector){
+      var nodes=[];
+      if (isF(selector) && selector.call !== undefined)
+        this.each(function(idx){
+          if (!selector.call(this,idx)) nodes.push(this);
+        });
+      else {
+        var excludes = typeof selector == 'string' ? this.filter(selector) :
+          (likeArray(selector) && isF(selector.item)) ? slice.call(selector) : $(selector);
+        this.forEach(function(el){
+          if (excludes.indexOf(el) < 0) nodes.push(el);
+        });
+      }
+      return $(nodes);
+    },
+    eq: function(idx){
+      return idx === -1 ? this.slice(idx) : this.slice(idx, + idx + 1);
+    },
+    first: function(){ var el = this[0]; return el && !isO(el) ? el : $(el) },
+    last: function(){ var el = this[this.length - 1]; return el && !isO(el) ? el : $(el) },
+    find: function(selector){
+      var result;
+      if (this.length == 1) result = $$(this[0], selector);
+      else result = this.map(function(){ return $$(this, selector) });
+      return $(result);
+    },
+    closest: function(selector, context){
+      var node = this[0], candidates = $$(context || document, selector);
+      if (!candidates.length) node = null;
+      while (node && candidates.indexOf(node) < 0)
+        node = node !== context && node !== document && node.parentNode;
+      return $(node);
+    },
+    parents: function(selector){
+      var ancestors = [], nodes = this;
+      while (nodes.length > 0)
+        nodes = $.map(nodes, function(node){
+          if ((node = node.parentNode) && node !== document && ancestors.indexOf(node) < 0) {
+            ancestors.push(node);
+            return node;
+          }
+        });
+      return filtered(ancestors, selector);
+    },
+    parent: function(selector){
+      return filtered(uniq(this.pluck('parentNode')), selector);
+    },
+    children: function(selector){
+      return filtered(this.map(function(){ return slice.call(this.children) }), selector);
+    },
+    siblings: function(selector){
+      return filtered(this.map(function(i, el){
+        return slice.call(el.parentNode.children).filter(function(child){ return child!==el });
+      }), selector);
+    },
+    empty: function(){ return this.each(function(){ this.innerHTML = '' }) },
+    pluck: function(property){ return this.map(function(){ return this[property] }) },
+    show: function(){
+      return this.each(function() {
+        this.style.display == "none" && (this.style.display = null);
+        if (getComputedStyle(this, '').getPropertyValue("display") == "none") {
+          this.style.display = defaultDisplay(this.nodeName)
+        }
+      })
+    },
+    replaceWith: function(newContent) {
+      return this.each(function() {
+        $(this).before(newContent).remove();
+      });
+    },
+    wrap: function(newContent) {
+      return this.each(function() {
+        $(this).wrapAll($(newContent)[0].cloneNode(false));
+      });
+    },
+    wrapAll: function(newContent) {
+      if (this[0]) {
+        $(this[0]).before(newContent = $(newContent));
+        newContent.append(this);
+      }
+      return this;
+    },
+    unwrap: function(){
+      this.parent().each(function(){
+        $(this).replaceWith($(this).children());
+      });
+      return this;
+    },
+    hide: function(){
+      return this.css("display", "none")
+    },
+    toggle: function(setting){
+      return (setting === undefined ? this.css("display") == "none" : setting) ? this.show() : this.hide();
+    },
+    prev: function(){ return $(this.pluck('previousElementSibling')) },
+    next: function(){ return $(this.pluck('nextElementSibling')) },
+    html: function(html){
+      return html === undefined ?
+        (this.length > 0 ? this[0].innerHTML : null) :
+        this.each(function (idx) {
+          var originHtml = this.innerHTML;
+          $(this).empty().append( funcArg(this, html, idx, originHtml) );
+        });
+    },
+    text: function(text){
+      return text === undefined ?
+        (this.length > 0 ? this[0].textContent : null) :
+        this.each(function(){ this.textContent = text });
+    },
+    attr: function(name, value){
+      var res;
+      return (typeof name == 'string' && value === undefined) ?
+        (this.length == 0 ? undefined :
+          (name == 'value' && this[0].nodeName == 'INPUT') ? this.val() :
+          (!(res = this[0].getAttribute(name)) && name in this[0]) ? this[0][name] : res
+        ) :
+        this.each(function(idx){
+          if (isO(name)) for (key in name) this.setAttribute(key, name[key])
+          else this.setAttribute(name, funcArg(this, value, idx, this.getAttribute(name)));
+        });
+    },
+    removeAttr: function(name) {
+      return this.each(function() { this.removeAttribute(name); });
+    },
+    data: function(name, value){
+      return this.attr('data-' + name, value);
+    },
+    val: function(value){
+      return (value === undefined) ?
+        (this.length > 0 ? this[0].value : null) :
+        this.each(function(idx){
+          this.value = funcArg(this, value, idx, this.value);
+        });
+    },
+    offset: function(){
+      if(this.length==0) return null;
+      var obj = this[0].getBoundingClientRect();
+      return {
+        left: obj.left + window.pageXOffset,
+        top: obj.top + window.pageYOffset,
+        width: obj.width,
+        height: obj.height
+      };
+    },
+    css: function(property, value){
+      if (value === undefined && typeof property == 'string') {
+        return(
+          this.length == 0
+            ? undefined
+            : this[0].style[camelize(property)] || getComputedStyle(this[0], '').getPropertyValue(property)
+        );
+      }
+      var css = '';
+      for (key in property) css += dasherize(key) + ':' + maybeAddPx(key, property[key]) + ';';
+      if (typeof property == 'string') css = dasherize(property) + ":" + maybeAddPx(property, value);
+      return this.each(function() { this.style.cssText += ';' + css });
+    },
+    index: function(element){
+      return element ? this.indexOf($(element)[0]) : this.parent().children().indexOf(this[0]);
+    },
+    hasClass: function(name){
+      if (this.length < 1) return false;
+      else return classRE(name).test(this[0].className);
+    },
+    addClass: function(name){
+      return this.each(function(idx) {
+        classList = [];
+        var cls = this.className, newName = funcArg(this, name, idx, cls);
+        newName.split(/\s+/g).forEach(function(klass) {
+          if (!$(this).hasClass(klass)) {
+            classList.push(klass)
+          }
+        }, this);
+        classList.length && (this.className += (cls ? " " : "") + classList.join(" "))
+      });
+    },
+    removeClass: function(name){
+      return this.each(function(idx) {
+        if(name === undefined)
+          return this.className = '';
+        classList = this.className;
+        funcArg(this, name, idx, classList).split(/\s+/g).forEach(function(klass) {
+          classList = classList.replace(classRE(klass), " ")
+        });
+        this.className = classList.trim()
+      });
+    },
+    toggleClass: function(name, when){
+      return this.each(function(idx){
+        var newName = funcArg(this, name, idx, this.className);
+        (when === undefined ? !$(this).hasClass(newName) : when) ?
+          $(this).addClass(newName) : $(this).removeClass(newName);
+      });
+    }
+  };
+
+  'filter,add,not,eq,first,last,find,closest,parents,parent,children,siblings'.split(',').forEach(function(property){
+    var fn = $.fn[property];
+    $.fn[property] = function() {
+      var ret = fn.apply(this, arguments);
+      ret.prevObject = this;
+      return ret;
+    }
+  });
+
+  ['width', 'height'].forEach(function(dimension){
+    $.fn[dimension] = function(value) {
+      var offset, Dimension = dimension.replace(/./, function(m) { return m[0].toUpperCase() });
+      if (value === undefined) return this[0] == window ? window['inner' + Dimension] :
+        this[0] == document ? document.documentElement['offset' + Dimension] :
+        (offset = this.offset()) && offset[dimension];
+      else return this.each(function(idx){
+        var el = $(this);
+        el.css(dimension, funcArg(this, value, idx, el[dimension]()));
+      });
+    }
+  });
+
+  function insert(operator, target, node) {
+    var parent = (operator % 2) ? target : target.parentNode;
+    parent && parent.insertBefore(node,
+      !operator ? target.nextSibling :      // after
+      operator == 1 ? parent.firstChild :   // prepend
+      operator == 2 ? target :              // before
+      null);                                // append
+  }
+
+  function traverseNode (node, fun) {
+    fun(node);
+    for (var key in node.childNodes) {
+      traverseNode(node.childNodes[key], fun);
+    }
+  }
+
+  adjacencyOperators.forEach(function(key, operator) {
+    $.fn[key] = function(html){
+      var nodes = isO(html) ? html : fragment(html);
+      if (!('length' in nodes) || nodes.nodeType) nodes = [nodes];
+      if (nodes.length < 1) return this;
+      var size = this.length, copyByClone = size > 1, inReverse = operator < 2;
+
+      return this.each(function(index, target){
+        for (var i = 0; i < nodes.length; i++) {
+          var node = nodes[inReverse ? nodes.length-i-1 : i];
+          traverseNode(node, function (node) {
+            if (node.nodeName != null && node.nodeName.toUpperCase() === 'SCRIPT' && (!node.type || node.type === 'text/javascript')) {
+              window['eval'].call(window, node.innerHTML);
+            }
+          });
+          if (copyByClone && index < size - 1) node = node.cloneNode(true);
+          insert(operator, target, node);
+        }
+      });
+    };
+
+    var reverseKey = (operator % 2) ? key+'To' : 'insert'+(operator ? 'Before' : 'After');
+    $.fn[reverseKey] = function(html) {
+      $(html)[key](this);
+      return this;
+    };
+  });
+
+  Z.prototype = $.fn;
+
+  return $;
+})();
+
+window.Zepto = Zepto;
+'$' in window || (window.$ = Zepto);
+//     Zepto.js
+//     (c) 2010, 2011 Thomas Fuchs
+//     Zepto.js may be freely distributed under the MIT license.
+
+(function($){
+  var $$ = $.qsa, handlers = {}, _zid = 1, specialEvents={};
+
+  specialEvents.click = specialEvents.mousedown = specialEvents.mouseup = specialEvents.mousemove = 'MouseEvents';
+
+  function zid(element) {
+    return element._zid || (element._zid = _zid++);
+  }
+  function findHandlers(element, event, fn, selector) {
+    event = parse(event);
+    if (event.ns) var matcher = matcherFor(event.ns);
+    return (handlers[zid(element)] || []).filter(function(handler) {
+      return handler
+        && (!event.e  || handler.e == event.e)
+        && (!event.ns || matcher.test(handler.ns))
+        && (!fn       || handler.fn == fn)
+        && (!selector || handler.sel == selector);
+    });
+  }
+  function parse(event) {
+    var parts = ('' + event).split('.');
+    return {e: parts[0], ns: parts.slice(1).sort().join(' ')};
+  }
+  function matcherFor(ns) {
+    return new RegExp('(?:^| )' + ns.replace(' ', ' .* ?') + '(?: |$)');
+  }
+
+  function eachEvent(events, fn, iterator){
+    if ($.isObject(events)) $.each(events, iterator);
+    else events.split(/\s/).forEach(function(type){ iterator(type, fn) });
+  }
+
+  function add(element, events, fn, selector, getDelegate){
+    var id = zid(element), set = (handlers[id] || (handlers[id] = []));
+    eachEvent(events, fn, function(event, fn){
+      var delegate = getDelegate && getDelegate(fn, event),
+        callback = delegate || fn;
+      var proxyfn = function (event) {
+        var result = callback.apply(element, [event].concat(event.data));
+        if (result === false) event.preventDefault();
+        return result;
+      };
+      var handler = $.extend(parse(event), {fn: fn, proxy: proxyfn, sel: selector, del: delegate, i: set.length});
+      set.push(handler);
+      element.addEventListener(handler.e, proxyfn, false);
+    });
+  }
+  function remove(element, events, fn, selector){
+    var id = zid(element);
+    eachEvent(events || '', fn, function(event, fn){
+      findHandlers(element, event, fn, selector).forEach(function(handler){
+        delete handlers[id][handler.i];
+        element.removeEventListener(handler.e, handler.proxy, false);
+      });
+    });
+  }
+
+  $.event = { add: add, remove: remove }
+
+  $.fn.bind = function(event, callback){
+    return this.each(function(){
+      add(this, event, callback);
+    });
+  };
+  $.fn.unbind = function(event, callback){
+    return this.each(function(){
+      remove(this, event, callback);
+    });
+  };
+  $.fn.one = function(event, callback){
+    return this.each(function(i, element){
+      add(this, event, callback, null, function(fn, type){
+        return function(){
+          var result = fn.apply(element, arguments);
+          remove(element, type, fn);
+          return result;
+        }
+      });
+    });
+  };
+
+  var returnTrue = function(){return true},
+      returnFalse = function(){return false},
+      eventMethods = {
+        preventDefault: 'isDefaultPrevented',
+        stopImmediatePropagation: 'isImmediatePropagationStopped',
+        stopPropagation: 'isPropagationStopped'
+      };
+  function createProxy(event) {
+    var proxy = $.extend({originalEvent: event}, event);
+    $.each(eventMethods, function(name, predicate) {
+      proxy[name] = function(){
+        this[predicate] = returnTrue;
+        return event[name].apply(event, arguments);
+      };
+      proxy[predicate] = returnFalse;
+    })
+    return proxy;
+  }
+
+  // emulates the 'defaultPrevented' property for browsers that have none
+  function fix(event) {
+    if (!('defaultPrevented' in event)) {
+      event.defaultPrevented = false;
+      var prevent = event.preventDefault;
+      event.preventDefault = function() {
+        this.defaultPrevented = true;
+        prevent.call(this);
+      }
+    }
+  }
+
+  $.fn.delegate = function(selector, event, callback){
+    return this.each(function(i, element){
+      add(element, event, callback, selector, function(fn){
+        return function(e){
+          var evt, match = $(e.target).closest(selector, element).get(0);
+          if (match) {
+            evt = $.extend(createProxy(e), {currentTarget: match, liveFired: element});
+            return fn.apply(match, [evt].concat([].slice.call(arguments, 1)));
+          }
+        }
+      });
+    });
+  };
+  $.fn.undelegate = function(selector, event, callback){
+    return this.each(function(){
+      remove(this, event, callback, selector);
+    });
+  }
+
+  $.fn.live = function(event, callback){
+    $(document.body).delegate(this.selector, event, callback);
+    return this;
+  };
+  $.fn.die = function(event, callback){
+    $(document.body).undelegate(this.selector, event, callback);
+    return this;
+  };
+
+  $.fn.on = function(event, selector, callback){
+    return selector === undefined || $.isFunction(selector) ?
+      this.bind(event, selector) : this.delegate(selector, event, callback);
+  };
+  $.fn.off = function(event, selector, callback){
+    return selector === undefined || $.isFunction(selector) ?
+      this.unbind(event, selector) : this.undelegate(selector, event, callback);
+  };
+
+  $.fn.trigger = function(event, data){
+    if (typeof event == 'string') event = $.Event(event);
+    fix(event);
+    event.data = data;
+    return this.each(function(){ this.dispatchEvent(event) });
+  };
+
+  // triggers event handlers on current element just as if an event occurred,
+  // doesn't trigger an actual event, doesn't bubble
+  $.fn.triggerHandler = function(event, data){
+    var e, result;
+    this.each(function(i, element){
+      e = createProxy(typeof event == 'string' ? $.Event(event) : event);
+      e.data = data; e.target = element;
+      $.each(findHandlers(element, event.type || event), function(i, handler){
+        result = handler.proxy(e);
+        if (e.isImmediatePropagationStopped()) return false;
+      });
+    });
+    return result;
+  };
+
+  // shortcut methods for `.bind(event, fn)` for each event type
+  ('focusin focusout load resize scroll unload click dblclick '+
+  'mousedown mouseup mousemove mouseover mouseout '+
+  'change select keydown keypress keyup error').split(' ').forEach(function(event) {
+    $.fn[event] = function(callback){ return this.bind(event, callback) };
+  });
+
+  ['focus', 'blur'].forEach(function(name) {
+    $.fn[name] = function(callback) {
+      if (callback) this.bind(name, callback);
+      else if (this.length) try { this.get(0)[name]() } catch(e){};
+      return this;
+    };
+  });
+
+  $.Event = function(type, props) {
+    var event = document.createEvent(specialEvents[type] || 'Events'), bubbles = true;
+    if (props) for (var name in props) (name == 'bubbles') ? (bubbles = !!props[name]) : (event[name] = props[name]);
+    event.initEvent(type, bubbles, true, null, null, null, null, null, null, null, null, null, null, null, null);
+    return event;
+  };
+
+})(Zepto);
+//     Zepto.js
+//     (c) 2010, 2011 Thomas Fuchs
+//     Zepto.js may be freely distributed under the MIT license.
+
+(function($){
+  function detect(ua){
+    var os = (this.os = {}), browser = (this.browser = {}),
+      webkit = ua.match(/WebKit\/([\d.]+)/),
+      android = ua.match(/(Android)\s+([\d.]+)/),
+      ipad = ua.match(/(iPad).*OS\s([\d_]+)/),
+      iphone = !ipad && ua.match(/(iPhone\sOS)\s([\d_]+)/),
+      webos = ua.match(/(webOS|hpwOS)[\s\/]([\d.]+)/),
+      touchpad = webos && ua.match(/TouchPad/),
+      blackberry = ua.match(/(BlackBerry).*Version\/([\d.]+)/);
+
+    if (webkit) browser.version = webkit[1];
+    browser.webkit = !!webkit;
+
+    if (android) os.android = true, os.version = android[2];
+    if (iphone) os.ios = true, os.version = iphone[2].replace(/_/g, '.'), os.iphone = true;
+    if (ipad) os.ios = true, os.version = ipad[2].replace(/_/g, '.'), os.ipad = true;
+    if (webos) os.webos = true, os.version = webos[2];
+    if (touchpad) os.touchpad = true;
+    if (blackberry) os.blackberry = true, os.version = blackberry[2];
+  }
+
+  // ### $.os
+  //
+  // Object containing information about browser platform
+  //
+  // *Example:*
+  //
+  //     $.os.ios      // => true if running on Apple iOS
+  //     $.os.android  // => true if running on Android
+  //     $.os.webos    // => true if running on HP/Palm WebOS
+  //     $.os.touchpad // => true if running on a HP TouchPad
+  //     $.os.version  // => string with a version number, e.g.
+  //                         "4.0", "3.1.1", "2.1", etc.
+  //     $.os.iphone   // => true if running on iPhone
+  //     $.os.ipad     // => true if running on iPad
+  //     $.os.blackberry // => true if running on BlackBerry
+  //
+  // ### $.browser
+  //
+  // *Example:*
+  //
+  //     $.browser.webkit  // => true if the browser is WebKit-based
+  //     $.browser.version // => WebKit version string
+  detect.call($, navigator.userAgent);
+
+  // make available to unit tests
+  $.__detect = detect;
+
+})(Zepto);
+//     Zepto.js
+//     (c) 2010, 2011 Thomas Fuchs
+//     Zepto.js may be freely distributed under the MIT license.
+
+(function($, undefined){
+  var prefix = '', eventPrefix, endEventName, endAnimationName,
+    vendors = {Webkit: 'webkit', Moz: '', O: 'o', ms: 'MS'},
+    document = window.document, testEl = document.createElement('div'),
+    supportedTransforms = /^((translate|rotate|scale)(X|Y|Z|3d)?|matrix(3d)?|perspective|skew(X|Y)?)$/i;
+
+  function downcase(str) { return str.toLowerCase() }
+  function normalizeEvent(name) { return eventPrefix ? eventPrefix + name : downcase(name) };
+
+  $.each(vendors, function(vendor, event){
+    if (testEl.style[vendor + 'TransitionProperty'] !== undefined) {
+      prefix = '-' + downcase(vendor) + '-';
+      eventPrefix = event;
+      return false;
+    }
+  });
+
+  $.fx = {
+    off: (eventPrefix === undefined && testEl.style.transitionProperty === undefined),
+    cssPrefix: prefix,
+    transitionEnd: normalizeEvent('TransitionEnd'),
+    animationEnd: normalizeEvent('AnimationEnd')
+  };
+
+  $.fn.animate = function(properties, duration, ease, callback){
+    if ($.isObject(duration))
+      ease = duration.easing, callback = duration.complete, duration = duration.duration;
+    if (duration) duration = duration / 1000;
+    return this.anim(properties, duration, ease, callback);
+  };
+
+  $.fn.anim = function(properties, duration, ease, callback){
+    var transforms, cssProperties = {}, key, that = this, wrappedCallback, endEvent = $.fx.transitionEnd;
+    if (duration === undefined) duration = 0.4;
+    if ($.fx.off) duration = 0;
+
+    if (typeof properties == 'string') {
+      // keyframe animation
+      cssProperties[prefix + 'animation-name'] = properties;
+      cssProperties[prefix + 'animation-duration'] = duration + 's';
+      endEvent = $.fx.animationEnd;
+    } else {
+      // CSS transitions
+      for (key in properties)
+        if (supportedTransforms.test(key)) {
+          transforms || (transforms = []);
+          transforms.push(key + '(' + properties[key] + ')');
+        }
+        else cssProperties[key] = properties[key];
+
+      if (transforms) cssProperties[prefix + 'transform'] = transforms.join(' ');
+      if (!$.fx.off) cssProperties[prefix + 'transition'] = 'all ' + duration + 's ' + (ease || '');
+    }
+
+    wrappedCallback = function(){
+      var props = {};
+      props[prefix + 'transition'] = props[prefix + 'animation-name'] = 'none';
+      $(this).css(props);
+      callback && callback.call(this);
+    }
+    if (duration > 0) this.one(endEvent, wrappedCallback);
+
+    setTimeout(function() {
+      that.css(cssProperties);
+      if (duration <= 0) setTimeout(function() {
+        that.each(function(){ wrappedCallback.call(this) });
+      }, 0);
+    }, 0);
+
+    return this;
+  };
+
+  testEl = null;
+})(Zepto);
+//     Zepto.js
+//     (c) 2010, 2011 Thomas Fuchs
+//     Zepto.js may be freely distributed under the MIT license.
+
+(function($){
+  var jsonpID = 0,
+      isObject = $.isObject,
+      document = window.document,
+      key,
+      name;
+
+  // trigger a custom event and return false if it was cancelled
+  function triggerAndReturn(context, eventName, data) {
+    var event = $.Event(eventName);
+    $(context).trigger(event, data);
+    return !event.defaultPrevented;
+  }
+
+  // trigger an Ajax "global" event
+  function triggerGlobal(settings, context, eventName, data) {
+    if (settings.global) return triggerAndReturn(context || document, eventName, data);
+  }
+
+  // Number of active Ajax requests
+  $.active = 0;
+
+  function ajaxStart(settings) {
+    if (settings.global && $.active++ === 0) triggerGlobal(settings, null, 'ajaxStart');
+  }
+  function ajaxStop(settings) {
+    if (settings.global && !(--$.active)) triggerGlobal(settings, null, 'ajaxStop');
+  }
+
+  // triggers an extra global event "ajaxBeforeSend" that's like "ajaxSend" but cancelable
+  function ajaxBeforeSend(xhr, settings) {
+    var context = settings.context;
+    if (settings.beforeSend.call(context, xhr, settings) === false ||
+        triggerGlobal(settings, context, 'ajaxBeforeSend', [xhr, settings]) === false)
+      return false;
+
+    triggerGlobal(settings, context, 'ajaxSend', [xhr, settings]);
+  }
+  function ajaxSuccess(data, xhr, settings) {
+    var context = settings.context, status = 'success';
+    settings.success.call(context, data, status, xhr);
+    triggerGlobal(settings, context, 'ajaxSuccess', [xhr, settings, data]);
+    ajaxComplete(status, xhr, settings);
+  }
+  // type: "timeout", "error", "abort", "parsererror"
+  function ajaxError(error, type, xhr, settings) {
+    var context = settings.context;
+    settings.error.call(context, xhr, type, error);
+    triggerGlobal(settings, context, 'ajaxError', [xhr, settings, error]);
+    ajaxComplete(type, xhr, settings);
+  }
+  // status: "success", "notmodified", "error", "timeout", "abort", "parsererror"
+  function ajaxComplete(status, xhr, settings) {
+    var context = settings.context;
+    settings.complete.call(context, xhr, status);
+    triggerGlobal(settings, context, 'ajaxComplete', [xhr, settings]);
+    ajaxStop(settings);
+  }
+
+  // Empty function, used as default callback
+  function empty() {}
+
+  // ### $.ajaxJSONP
+  //
+  // Load JSON from a server in a different domain (JSONP)
+  //
+  // *Arguments:*
+  //
+  //     options — object that configure the request,
+  //               see avaliable options below
+  //
+  // *Avaliable options:*
+  //
+  //     url     — url to which the request is sent
+  //     success — callback that is executed if the request succeeds
+  //     error   — callback that is executed if the server drops error
+  //     context — in which context to execute the callbacks in
+  //
+  // *Example:*
+  //
+  //     $.ajaxJSONP({
+  //        url:     'http://example.com/projects?callback=?',
+  //        success: function (data) {
+  //            projects.push(json);
+  //        }
+  //     });
+  //
+  $.ajaxJSONP = function(options){
+    var callbackName = 'jsonp' + (++jsonpID),
+      script = document.createElement('script'),
+      abort = function(){
+        $(script).remove();
+        if (callbackName in window) window[callbackName] = empty;
+        ajaxComplete(xhr, options, 'abort');
+      },
+      xhr = { abort: abort }, abortTimeout;
+
+    window[callbackName] = function(data){
+      clearTimeout(abortTimeout);
+      $(script).remove();
+      delete window[callbackName];
+      ajaxSuccess(data, xhr, options);
+    };
+
+    script.src = options.url.replace(/=\?/, '=' + callbackName);
+    $('head').append(script);
+
+    if (options.timeout > 0) abortTimeout = setTimeout(function(){
+        xhr.abort();
+        ajaxComplete(xhr, options, 'timeout');
+      }, options.timeout);
+
+    return xhr;
+  };
+
+  // ### $.ajaxSettings
+  //
+  // AJAX settings
+  //
+  $.ajaxSettings = {
+    // Default type of request
+    type: 'GET',
+    // Callback that is executed before request
+    beforeSend: empty,
+    // Callback that is executed if the request succeeds
+    success: empty,
+    // Callback that is executed the the server drops error
+    error: empty,
+    // Callback that is executed on request complete (both: error and success)
+    complete: empty,
+    // The context for the callbacks
+    context: null,
+    // Whether to trigger "global" Ajax events
+    global: true,
+    // Transport
+    xhr: function () {
+      return new window.XMLHttpRequest();
+    },
+    // MIME types mapping
+    accepts: {
+      script: 'text/javascript, application/javascript',
+      json:   'application/json',
+      xml:    'application/xml, text/xml',
+      html:   'text/html',
+      text:   'text/plain'
+    },
+    // Whether the request is to another domain
+    crossDomain: false,
+    // Default timeout
+    timeout: 0
+  };
+
+  // ### $.ajax
+  //
+  // Perform AJAX request
+  //
+  // *Arguments:*
+  //
+  //     options — object that configure the request,
+  //               see avaliable options below
+  //
+  // *Avaliable options:*
+  //
+  //     type ('GET')          — type of request GET / POST
+  //     url (window.location) — url to which the request is sent
+  //     data                  — data to send to server,
+  //                             can be string or object
+  //     dataType ('json')     — what response type you accept from
+  //                             the server:
+  //                             'json', 'xml', 'html', or 'text'
+  //     timeout (0)           — request timeout
+  //     beforeSend            — callback that is executed before
+  //                             request send
+  //     complete              — callback that is executed on request
+  //                             complete (both: error and success)
+  //     success               — callback that is executed if
+  //                             the request succeeds
+  //     error                 — callback that is executed if
+  //                             the server drops error
+  //     context               — in which context to execute the
+  //                             callbacks in
+  //
+  // *Example:*
+  //
+  //     $.ajax({
+  //        type:       'POST',
+  //        url:        '/projects',
+  //        data:       { name: 'Zepto.js' },
+  //        dataType:   'html',
+  //        timeout:    100,
+  //        context:    $('body'),
+  //        success:    function (data) {
+  //            this.append(data);
+  //        },
+  //        error:    function (xhr, type) {
+  //            alert('Error!');
+  //        }
+  //     });
+  //
+  $.ajax = function(options){
+    var settings = $.extend({}, options || {});
+    for (key in $.ajaxSettings) if (settings[key] === undefined) settings[key] = $.ajaxSettings[key];
+
+    ajaxStart(settings);
+
+    if (!settings.crossDomain) settings.crossDomain = /^([\w-]+:)?\/\/([^\/]+)/.test(settings.url) &&
+      RegExp.$2 != window.location.host;
+
+    if (/=\?/.test(settings.url)) return $.ajaxJSONP(settings);
+
+    if (!settings.url) settings.url = window.location.toString();
+    if (settings.data && !settings.contentType) settings.contentType = 'application/x-www-form-urlencoded';
+    if (isObject(settings.data)) settings.data = $.param(settings.data);
+
+    if (settings.type.match(/get/i) && settings.data) {
+      var queryString = settings.data;
+      if (settings.url.match(/\?.*=/)) {
+        queryString = '&' + queryString;
+      } else if (queryString[0] != '?') {
+        queryString = '?' + queryString;
+      }
+      settings.url += queryString;
+    }
+
+    var mime = settings.accepts[settings.dataType],
+        baseHeaders = { },
+        protocol = /^([\w-]+:)\/\//.test(settings.url) ? RegExp.$1 : window.location.protocol,
+        xhr = $.ajaxSettings.xhr(), abortTimeout;
+
+    if (!settings.crossDomain) baseHeaders['X-Requested-With'] = 'XMLHttpRequest';
+    if (mime) baseHeaders['Accept'] = mime;
+    settings.headers = $.extend(baseHeaders, settings.headers || {});
+
+    xhr.onreadystatechange = function(){
+      if (xhr.readyState == 4) {
+        clearTimeout(abortTimeout);
+        var result, error = false;
+        if ((xhr.status >= 200 && xhr.status < 300) || (xhr.status == 0 && protocol == 'file:')) {
+          if (mime == 'application/json' && !(/^\s*$/.test(xhr.responseText))) {
+            try { result = JSON.parse(xhr.responseText); }
+            catch (e) { error = e; }
+          }
+          else result = xhr.responseText;
+          if (error) ajaxError(error, 'parsererror', xhr, settings);
+          else ajaxSuccess(result, xhr, settings);
+        } else {
+          ajaxError(null, 'error', xhr, settings);
+        }
+      }
+    };
+
+    xhr.open(settings.type, settings.url, true);
+
+    if (settings.contentType) settings.headers['Content-Type'] = settings.contentType;
+    for (name in settings.headers) xhr.setRequestHeader(name, settings.headers[name]);
+
+    if (ajaxBeforeSend(xhr, settings) === false) {
+      xhr.abort();
+      return false;
+    }
+
+    if (settings.timeout > 0) abortTimeout = setTimeout(function(){
+        xhr.onreadystatechange = empty;
+        xhr.abort();
+        ajaxError(null, 'timeout', xhr, settings);
+      }, settings.timeout);
+
+    xhr.send(settings.data);
+    return xhr;
+  };
+
+  // ### $.get
+  //
+  // Load data from the server using a GET request
+  //
+  // *Arguments:*
+  //
+  //     url     — url to which the request is sent
+  //     success — callback that is executed if the request succeeds
+  //
+  // *Example:*
+  //
+  //     $.get(
+  //        '/projects/42',
+  //        function (data) {
+  //            $('body').append(data);
+  //        }
+  //     );
+  //
+  $.get = function(url, success){ return $.ajax({ url: url, success: success }) };
+
+  // ### $.post
+  //
+  // Load data from the server using POST request
+  //
+  // *Arguments:*
+  //
+  //     url        — url to which the request is sent
+  //     [data]     — data to send to server, can be string or object
+  //     [success]  — callback that is executed if the request succeeds
+  //     [dataType] — type of expected response
+  //                  'json', 'xml', 'html', or 'text'
+  //
+  // *Example:*
+  //
+  //     $.post(
+  //        '/projects',
+  //        { name: 'Zepto.js' },
+  //        function (data) {
+  //            $('body').append(data);
+  //        },
+  //        'html'
+  //     );
+  //
+  $.post = function(url, data, success, dataType){
+    if ($.isFunction(data)) dataType = dataType || success, success = data, data = null;
+    return $.ajax({ type: 'POST', url: url, data: data, success: success, dataType: dataType });
+  };
+
+  // ### $.getJSON
+  //
+  // Load JSON from the server using GET request
+  //
+  // *Arguments:*
+  //
+  //     url     — url to which the request is sent
+  //     success — callback that is executed if the request succeeds
+  //
+  // *Example:*
+  //
+  //     $.getJSON(
+  //        '/projects/42',
+  //        function (json) {
+  //            projects.push(json);
+  //        }
+  //     );
+  //
+  $.getJSON = function(url, success){
+    return $.ajax({ url: url, success: success, dataType: 'json' });
+  };
+
+  // ### $.fn.load
+  //
+  // Load data from the server into an element
+  //
+  // *Arguments:*
+  //
+  //     url     — url to which the request is sent
+  //     [success] — callback that is executed if the request succeeds
+  //
+  // *Examples:*
+  //
+  //     $('#project_container').get(
+  //        '/projects/42',
+  //        function () {
+  //            alert('Project was successfully loaded');
+  //        }
+  //     );
+  //
+  //     $('#project_comments').get(
+  //        '/projects/42 #comments',
+  //        function () {
+  //            alert('Comments was successfully loaded');
+  //        }
+  //     );
+  //
+  $.fn.load = function(url, success){
+    if (!this.length) return this;
+    var self = this, parts = url.split(/\s/), selector;
+    if (parts.length > 1) url = parts[0], selector = parts[1];
+    $.get(url, function(response){
+      self.html(selector ?
+        $(document.createElement('div')).html(response).find(selector).html()
+        : response);
+      success && success.call(self);
+    });
+    return this;
+  };
+
+  var escape = encodeURIComponent;
+
+  function serialize(params, obj, traditional, scope){
+    var array = $.isArray(obj);
+    $.each(obj, function(key, value) {
+      if (scope) key = traditional ? scope : scope + '[' + (array ? '' : key) + ']';
+      // handle data in serializeArray() format
+      if (!scope && array) params.add(value.name, value.value);
+      // recurse into nested objects
+      else if (traditional ? $.isArray(value) : isObject(value))
+        serialize(params, value, traditional, key);
+      else params.add(key, value);
+    });
+  }
+
+  // ### $.param
+  //
+  // Encode object as a string of URL-encoded key-value pairs
+  //
+  // *Arguments:*
+  //
+  //     obj — object to serialize
+  //     [traditional] — perform shallow serialization
+  //
+  // *Example:*
+  //
+  //     $.param( { name: 'Zepto.js', version: '0.6' } );
+  //
+  $.param = function(obj, traditional){
+    var params = [];
+    params.add = function(k, v){ this.push(escape(k) + '=' + escape(v)) };
+    serialize(params, obj, traditional);
+    return params.join('&').replace('%20', '+');
+  };
+})(Zepto);
+//     Zepto.js
+//     (c) 2010, 2011 Thomas Fuchs
+//     Zepto.js may be freely distributed under the MIT license.
+
+(function ($) {
+
+  // ### $.fn.serializeArray
+  //
+  // Encode a set of form elements as an array of names and values
+  //
+  // *Example:*
+  //
+  //     $('#login_form').serializeArray();
+  //
+  //  returns
+  //
+  //     [
+  //         {
+  //             name: 'email',
+  //             value: 'koss@nocorp.me'
+  //         },
+  //         {
+  //             name: 'password',
+  //             value: '123456'
+  //         }
+  //     ]
+  //
+  $.fn.serializeArray = function () {
+    var result = [], el;
+    $( Array.prototype.slice.call(this.get(0).elements) ).each(function () {
+      el = $(this);
+      var type = el.attr('type');
+      if (
+        !this.disabled && type != 'submit' && type != 'reset' && type != 'button' &&
+        ((type != 'radio' && type != 'checkbox') || this.checked)
+      ) {
+        result.push({
+          name: el.attr('name'),
+          value: el.val()
+        });
+      }
+    });
+    return result;
+  };
+
+  // ### $.fn.serialize
+  //
+  //
+  // Encode a set of form elements as a string for submission
+  //
+  // *Example:*
+  //
+  //     $('#login_form').serialize();
+  //
+  //  returns
+  //
+  //     "email=koss%40nocorp.me&password=123456"
+  //
+  $.fn.serialize = function () {
+    var result = [];
+    this.serializeArray().forEach(function (elm) {
+      result.push( encodeURIComponent(elm.name) + '=' + encodeURIComponent(elm.value) );
+    });
+    return result.join('&');
+  };
+
+  // ### $.fn.submit
+  //
+  // Bind or trigger the submit event for a form
+  //
+  // *Examples:*
+  //
+  // To bind a handler for the submit event:
+  //
+  //     $('#login_form').submit(function (e) {
+  //         alert('Form was submitted!');
+  //         e.preventDefault();
+  //     });
+  //
+  // To trigger form submit:
+  //
+  //     $('#login_form').submit();
+  //
+  $.fn.submit = function (callback) {
+    if (callback) this.bind('submit', callback)
+    else if (this.length) {
+      var event = $.Event('submit');
+      this.eq(0).trigger(event);
+      if (!event.defaultPrevented) this.get(0).submit()
+    }
+    return this;
+  }
+
+})(Zepto);
+//     Zepto.js
+//     (c) 2010, 2011 Thomas Fuchs
+//     Zepto.js may be freely distributed under the MIT license.
+
+(function($){
+  var touch = {}, touchTimeout;
+
+  function parentIfText(node){
+    return 'tagName' in node ? node : node.parentNode;
+  }
+
+  function swipeDirection(x1, x2, y1, y2){
+    var xDelta = Math.abs(x1 - x2), yDelta = Math.abs(y1 - y2);
+    if (xDelta >= yDelta) {
+      return (x1 - x2 > 0 ? 'Left' : 'Right');
+    } else {
+      return (y1 - y2 > 0 ? 'Up' : 'Down');
+    }
+  }
+
+  var longTapDelay = 750;
+  function longTap(){
+    if (touch.last && (Date.now() - touch.last >= longTapDelay)) {
+      $(touch.target).trigger('longTap');
+      touch = {};
+    }
+  }
+
+  $(document).ready(function(){
+    $(document.body).bind('touchstart', function(e){
+      var now = Date.now(), delta = now - (touch.last || now);
+      touch.target = parentIfText(e.touches[0].target);
+      touchTimeout && clearTimeout(touchTimeout);
+      touch.x1 = e.touches[0].pageX;
+      touch.y1 = e.touches[0].pageY;
+      if (delta > 0 && delta <= 250) touch.isDoubleTap = true;
+      touch.last = now;
+      setTimeout(longTap, longTapDelay);
+    }).bind('touchmove', function(e){
+      touch.x2 = e.touches[0].pageX;
+      touch.y2 = e.touches[0].pageY;
+    }).bind('touchend', function(e){
+      if (touch.isDoubleTap) {
+        $(touch.target).trigger('doubleTap');
+        touch = {};
+      } else if (touch.x2 > 0 || touch.y2 > 0) {
+        (Math.abs(touch.x1 - touch.x2) > 30 || Math.abs(touch.y1 - touch.y2) > 30)  &&
+          $(touch.target).trigger('swipe') &&
+          $(touch.target).trigger('swipe' + (swipeDirection(touch.x1, touch.x2, touch.y1, touch.y2)));
+        touch.x1 = touch.x2 = touch.y1 = touch.y2 = touch.last = 0;
+      } else if ('last' in touch) {
+        touchTimeout = setTimeout(function(){
+          touchTimeout = null;
+          $(touch.target).trigger('tap')
+          touch = {};
+        }, 250);
+      }
+    }).bind('touchcancel', function(){ touch = {} });
+  });
+
+  ['swipe', 'swipeLeft', 'swipeRight', 'swipeUp', 'swipeDown', 'doubleTap', 'tap', 'longTap'].forEach(function(m){
+    $.fn[m] = function(callback){ return this.bind(m, callback) }
+  });
+})(Zepto);
+jQuery = Zepto;

--- a/readme.md
+++ b/readme.md
@@ -33,15 +33,17 @@ plugin.
 ### Prerequisites
 
 * Backbone.js v0.5.1 or higher
-* jQuery v1.6.2 or higher
+* jQuery v1.6.2 or higher; or Zepto v0.8 or higher
 
 This is a plugin for Backbone.js and is built and tested against Backbone v0.5.1. It also uses jQuery
 to perform most of the binding and manipulations, and is built and tested against v1.6.1. However, I am
 currently using this plugin in a production application with Backbone v0.3.3 and jQuery v1.5.1. 
 
-At this point, I make no guarantees of it working with any version of Backbone or jQuery, 
+At this point, I make no guarantees of it working with any version of Backbone, jQuery or Zepto, 
 other than what it has been built and tested against. It works for me, so it may work for you
 with versions other than what is stated
+
+Zepto does not support typeless binding of inputs due to limit selector support.
 
 ### Get The ModelBinding Plugin
 

--- a/spec/SpecRunnerZepto.html
+++ b/spec/SpecRunnerZepto.html
@@ -42,14 +42,14 @@
 
   <!-- include source files here... -->
   <script type="text/javascript" src="../public/javascripts/underscore.js"></script>
-  <script type="text/javascript" src="../public/javascripts/jquery-1.6.2.js"></script> 
+  <!--<script type="text/javascript" src="../public/javascripts/jquery-1.6.2.js"></script> -->
+  <script type="text/javascript" src="../public/javascripts/zepto.js"></script>
   <script type="text/javascript" src="../public/javascripts/backbone.js"></script>
   <script type="text/javascript" src="../backbone.modelbinding.js"></script>
 
 
   <!-- include spec files here... -->
   <script type="text/javascript" src="javascripts/helpers/SpecHelper.js"></script>
-  <script type="text/javascript" src="javascripts/helpers/jasmine-jquery.js"></script>
   <script type="text/javascript" src="javascripts/helpers/sample.backbone.app.js"></script>
 
   <script type="text/javascript" src="javascripts/checkboxConventionBindings.spec.js"></script>

--- a/spec/javascripts/checkboxConventionBindings.spec.js
+++ b/spec/javascripts/checkboxConventionBindings.spec.js
@@ -11,19 +11,23 @@ describe("checkbox convention bindings", function(){
     });
 
     it("bind view changes to the model's field", function(){
-      var el = this.view.$("#drivers_license");
+      var el = $(this.view.el).find("#drivers_license");
       el.removeAttr("checked");
       el.trigger('change');
       expect(this.model.get('drivers_license')).toBeFalsy();
     });
 
-    it("bind model field changes to the form input", function(){
-      var el = this.view.$("#drivers_license");
+    it("bind model field changes to the form input when checked", function(){
+      var el = $(this.view.el).find("#drivers_license");
 
       // uncheck it
       this.model.set({drivers_license: false});
       var selected = el.attr("checked");
       expect(selected).toBeFalsy();
+    });
+
+    it("bind model field changes to the form input when checked", function(){
+      var el = $(this.view.el).find("#drivers_license");
 
       // then check it
       this.model.set({drivers_license: true});
@@ -32,14 +36,14 @@ describe("checkbox convention bindings", function(){
     });
 
     it("checks the box for a truthy value, on render", function(){
-      var el = this.view.$("#drivers_license");
+      var el = $(this.view.el).find("#drivers_license");
       var selected = el.attr("checked");
 
       expect(selected).toBeTruthy();
     });
 
     it("unchecks the box for a falsy value, on render", function(){
-      var el = this.view.$("#motorcycle_license");
+      var el = $(this.view.el).find("#motorcycle_license");
       var selected = el.attr("checked");
 
       expect(selected).toBeFalsy();
@@ -53,7 +57,7 @@ describe("checkbox convention bindings", function(){
       });
       this.view = new AView({model: this.model});
       this.view.render();
-      this.el = this.view.$("#binary_checkbox");
+      this.el = $(this.view.el).find("#binary_checkbox");
     });
 
     it("checks the box for a 1 (one) value, on render", function(){
@@ -76,7 +80,7 @@ describe("checkbox convention bindings", function(){
       });
       this.view = new AView({model: this.model});
       this.view.render();
-      this.el = this.view.$("#binary_checkbox");
+      this.el = $(this.view.el).find("#binary_checkbox");
     });
 
     it("unchecks the box for a 0 (zero) value, on render", function(){

--- a/spec/javascripts/configurableBindingAttributes.spec.js
+++ b/spec/javascripts/configurableBindingAttributes.spec.js
@@ -13,7 +13,7 @@ describe("configurableBindingAttributes", function(){
 
   describe("text element binding using configurable attribute", function(){
     it("bind view changes to the model's field, by configurable convention", function(){
-      var el = this.view.$(".super_power");
+      var el = $(this.view.el).find(".super_power");
       el.val("x ray vision");
       el.trigger('change');
 
@@ -22,19 +22,19 @@ describe("configurableBindingAttributes", function(){
 
     it("bind model field changes to the form input, by convention of id", function(){
       this.model.set({super_power: "eating raw vegetables"});
-      var el = this.view.$(".super_power");
+      var el = $(this.view.el).find(".super_power");
       expect(el.val()).toEqual("eating raw vegetables");
     });
 
     it("binds the model's value to the form field on render", function(){
-      var el = this.view.$(".super_power");
+      var el = $(this.view.el).find(".super_power");
       expect(el.val()).toEqual("mega pooping");
     });
   });
   
   describe("radio element binding using configurable attribute", function(){
     it("bind view changes to the model's field, by configurable convention", function(){
-      var el = this.view.$("#graduated_no");
+      var el = $(this.view.el).find("#graduated_no");
       el.attr("checked", "checked");
       el.trigger('change');
       expect(this.model.get('graduated')).toEqual("no");
@@ -42,14 +42,14 @@ describe("configurableBindingAttributes", function(){
 
     it("bind model field changes to the form input, by configurable convention", function(){
       this.model.set({graduated: "yes"});
-      var el = this.view.$("#graduated_yes");
+      var el = $(this.view.el).find("#graduated_yes");
       var selected = el.attr("checked");
 
       expect(selected).toBeTruthy();
     });
 
     it("binds the model's value to the form field on render", function(){
-      var el = this.view.$("input[type=radio][class=graduated]:checked");
+      var el = $(this.view.el).find("input[type=radio][class=graduated]:checked");
       var selected = el.val();
 
       expect(selected).toBe("maybe");
@@ -58,7 +58,7 @@ describe("configurableBindingAttributes", function(){
 
   describe("select element binding using configurable attribute", function(){
     it("bind view changes to the model's field, by configurable convention", function(){
-      var el = this.view.$(".education");
+      var el = $(this.view.el).find(".education");
       el.val("college");
       el.trigger('change');
 
@@ -67,17 +67,17 @@ describe("configurableBindingAttributes", function(){
 
     it("bind model field changes to the form input, by configurable convention", function(){
       this.model.set({education: "high school"});
-      var el = this.view.$(".education");
+      var el = $(this.view.el).find(".education");
       expect(el.val()).toEqual("high school");
     });
 
     it("binds the model's value to the form field on render", function(){
-      var el = this.view.$(".education");
+      var el = $(this.view.el).find(".education");
       expect(el.val()).toEqual("graduate");
     });
 
     it("applies the text of the selection to the model", function(){
-      var el = this.view.$(".education");
+      var el = $(this.view.el).find(".education");
       el.val("grade_school");
       el.trigger('change');
 
@@ -87,14 +87,14 @@ describe("configurableBindingAttributes", function(){
 
   describe("checkbox element binding using configurable attribute", function(){
     it("bind view changes to the model's field", function(){
-      var el = this.view.$(".drivers_license");
+      var el = $(this.view.el).find(".drivers_license");
       el.removeAttr("checked");
       el.trigger('change');
       expect(this.model.get('drivers_license')).toBeFalsy();
     });
 
     it("bind model field changes to the form input", function(){
-      var el = this.view.$(".drivers_license");
+      var el = $(this.view.el).find(".drivers_license");
 
       // uncheck it
       this.model.set({drivers_license: false});
@@ -108,7 +108,7 @@ describe("configurableBindingAttributes", function(){
     });
 
     it("binds the model's value to the form field on render", function(){
-      var el = this.view.$(".drivers_license");
+      var el = $(this.view.el).find(".drivers_license");
       var selected = el.attr("checked");
 
       expect(selected).toBeTruthy();

--- a/spec/javascripts/dataBindConvention.spec.js
+++ b/spec/javascripts/dataBindConvention.spec.js
@@ -76,14 +76,16 @@ describe("data-bind conventions", function(){
     });
 
     it("should set the element's disabled value to the model's value, immediately", function(){
-      var disabled = this.el.attr("disabled");
-      expect(disabled == true || disabled == 'true').toBeTruthy();
+      expect(this.el.attr("disabled")).toBeTruthy();
     });
 
     it("should set the element's disabled value when the model's value is changed", function(){
       this.model.set({isValid: true});
-      var disabled = this.el.attr("disabled");
-      expect( disabled == false || disabled == 'false').toBeTruthy();
+      if ( window.Zepto ) {
+        expect(this.el.attr("disabled")).toBe('false');
+      } else {
+        expect(this.el.attr("disabled")).toBeFalsy();
+      }
     });
   });
 
@@ -94,14 +96,16 @@ describe("data-bind conventions", function(){
     });
 
     it("should set the element's disabled value to the model's value, immediately", function(){
-      var disabled = this.el.attr("disabled");
-      expect( disabled == false || disabled == 'false').toBeTruthy();
+      if ( window.Zepto ) {
+        expect(this.el.attr("disabled")).toBe('false');
+      } else {
+        expect(this.el.attr("disabled")).toBeFalsy();
+      }
     });
 
     it("should set the element's disabled value when the model's value is changed", function(){
       this.model.set({isValid: true});
-      var disabled = this.el.attr("disabled");
-      expect(disabled == true || disabled == 'true').toBeTruthy();
+      expect(this.el.attr("disabled")).toBeTruthy(); 
     });
   });
 
@@ -133,7 +137,11 @@ describe("data-bind conventions", function(){
 
     it("should set the element's disabled value when the model's value is changed", function(){
       this.model.set({isValid: true});
-      expect(this.el.css('display')).toBe('node');
+      if ( window.Zepto ) {
+
+      } else {
+        expect(this.el).toBeHidden();
+      }
     });
   });
   
@@ -149,7 +157,7 @@ describe("data-bind conventions", function(){
 
     it("should set the element's disabled value when the model's value is changed", function(){
       this.model.set({isValid: true});
-      expect(this.el.css('display').toBe('none');
+      expect(this.el.css('display')).toBe('none');
     });
   });
 });

--- a/spec/javascripts/dataBindConvention.spec.js
+++ b/spec/javascripts/dataBindConvention.spec.js
@@ -12,7 +12,7 @@ describe("data-bind conventions", function(){
   describe("when data-bind is configured for an event and the event is triggered", function(){
     beforeEach(function(){
       this.view.render();
-      this.el = this.view.$("#eventDiv");
+      this.el = $(this.view.el).find("#eventDiv");
       this.model.trigger("foo", "bar");
     });
 
@@ -24,7 +24,7 @@ describe("data-bind conventions", function(){
   describe("when a data-bind is configured with no html element attribute specified", function(){
     beforeEach(function(){
       this.view.render();
-      this.el = this.view.$("#doctor_no_elem");
+      this.el = $(this.view.el).find("#doctor_no_elem");
     });
 
     it("should set the element's text to the model's property value immediately", function(){
@@ -40,7 +40,7 @@ describe("data-bind conventions", function(){
   describe("when a data-bind is configured to set text", function(){
     beforeEach(function(){
       this.view.render();
-      this.el = this.view.$("#doctor");
+      this.el = $(this.view.el).find("#doctor");
     });
 
     it("should set the element's text to the model's property value immediately", function(){
@@ -56,7 +56,7 @@ describe("data-bind conventions", function(){
   describe("when a data-bind is configured to set html", function(){
     beforeEach(function(){
       this.view.render();
-      this.el = this.view.$("#villain");
+      this.el = $(this.view.el).find("#villain");
     });
 
     it("should set the element's contents to the model's property value immediately", function(){
@@ -72,39 +72,43 @@ describe("data-bind conventions", function(){
   describe("when a data-bind is configured to set enabled", function(){
     beforeEach(function(){
       this.view.render();
-      this.el = this.view.$("#clicker");
+      this.el = $(this.view.el).find("#clicker");
     });
 
     it("should set the element's disabled value to the model's value, immediately", function(){
-      expect(this.el.attr("disabled")).toBeTruthy();
+      var disabled = this.el.attr("disabled");
+      expect(disabled == true || disabled == 'true').toBeTruthy();
     });
 
     it("should set the element's disabled value when the model's value is changed", function(){
       this.model.set({isValid: true});
-      expect(this.el.attr("disabled")).toBeFalsy();
+      var disabled = this.el.attr("disabled");
+      expect( disabled == false || disabled == 'false').toBeTruthy();
     });
   });
 
   describe("when a data-bind is configured to set disabled", function(){
     beforeEach(function(){
       this.view.render();
-      this.el = this.view.$("#unclicker");
+      this.el = $(this.view.el).find("#unclicker");
     });
 
     it("should set the element's disabled value to the model's value, immediately", function(){
-      expect(this.el.attr("disabled")).toBeFalsy();
+      var disabled = this.el.attr("disabled");
+      expect( disabled == false || disabled == 'false').toBeTruthy();
     });
 
     it("should set the element's disabled value when the model's value is changed", function(){
       this.model.set({isValid: true});
-      expect(this.el.attr("disabled")).toBeTruthy();
+      var disabled = this.el.attr("disabled");
+      expect(disabled == true || disabled == 'true').toBeTruthy();
     });
   });
 
   describe("when a data-bind is configured to set an arbitrary attribute", function(){
     beforeEach(function(){
       this.view.render();
-      this.el = this.view.$("#pet");
+      this.el = $(this.view.el).find("#pet");
     });
 
     it("should set the element's attribute to the model's property value immediately", function(){
@@ -120,7 +124,7 @@ describe("data-bind conventions", function(){
   describe("when a data-bind is configured to set displayed", function(){
     beforeEach(function(){
       this.view.render();
-      this.el = this.view.$("#showHideThing");
+      this.el = $(this.view.el).find("#showHideThing");
     });
 
     it("should set the element's disabled value to the model's value, immediately", function(){
@@ -129,14 +133,14 @@ describe("data-bind conventions", function(){
 
     it("should set the element's disabled value when the model's value is changed", function(){
       this.model.set({isValid: true});
-      expect(this.el).toBeHidden();
+      expect(this.el.css('display')).toBe('node');
     });
   });
   
   describe("when a data-bind is configured to set visible", function(){
     beforeEach(function(){
       this.view.render();
-      this.el = this.view.$("#showHideAnotherThing");
+      this.el = $(this.view.el).find("#showHideAnotherThing");
     });
 
     it("should set the element's disabled value to the model's value, immediately", function(){
@@ -145,7 +149,7 @@ describe("data-bind conventions", function(){
 
     it("should set the element's disabled value when the model's value is changed", function(){
       this.model.set({isValid: true});
-      expect(this.el).toBeHidden();
+      expect(this.el.css('display').toBe('none');
     });
   });
 });

--- a/spec/javascripts/dataBindMultiple.spec.js
+++ b/spec/javascripts/dataBindMultiple.spec.js
@@ -6,7 +6,7 @@ describe("data-bind multiple attributes", function(){
     });
     this.view = new AView({model: this.model});
     this.view.render();
-    this.el = this.view.$("#avatar");
+    this.el = $(this.view.el).find("#avatar");
   });
 
   describe ("when initializing", function(){

--- a/spec/javascripts/helpers/sample.backbone.app.js
+++ b/spec/javascripts/helpers/sample.backbone.app.js
@@ -3,11 +3,11 @@ AModel = Backbone.Model.extend({});
 AView = Backbone.View.extend({
   render: function(){
     var html = $("\
-      <div id='eventDiv' data-bind='text event:foo' />\
+      <div id='eventDiv' data-bind='text event:foo' /></div>\
       <img id='avatar' data-bind='src url; class name'>\
       <input id='noType'>\
-      <div id='showHideThing' data-bind='displayed isValid' />\
-      <div id='showHideAnotherThing' data-bind='hidden isValid' />\
+      <div id='showHideThing' data-bind='displayed isValid' ></div>\
+      <div id='showHideAnotherThing' data-bind='hidden isValid' ></div>\
       <button id='unclicker' data-bind='disabled isValid'>Click Me!</button>\
       <button id='clicker' data-bind='enabled isValid'>Click Me!</button>\
       <div id='villain' data-bind='html villain'><p>test</p></div>\
@@ -62,7 +62,7 @@ AView = Backbone.View.extend({
       <input type='tel' id='tel'>\
       <input type='search' id='search'>\
       ");
-    this.$(this.el).append(html);
+    $(this.el).html(html);
     Backbone.ModelBinding.bind(this);
   }
 });
@@ -84,7 +84,7 @@ AllBindingAttributesView = Backbone.View.extend({
       <input type='checkbox' id='v_drivers_license' class='drivers_license' value='yes'>\
       <textarea id='v_bio' class='bio'></textarea>\
     ");
-    this.$(this.el).append(html);
+    $(this.el).append(html);
 
     Backbone.ModelBinding.bind(this, {all: "class"});
   }
@@ -107,7 +107,7 @@ GlobalAllBindingAttributesView = Backbone.View.extend({
       <input type='checkbox' id='v_drivers_license' class='drivers_license' value='yes'>\
       <textarea id='v_bio' class='bio'></textarea>\
     ");
-    this.$(this.el).append(html);
+    $(this.el).append(html);
 
     Backbone.ModelBinding.bind(this);
   }
@@ -130,7 +130,7 @@ AnotherView = Backbone.View.extend({
       <input type='checkbox' class='drivers_license' value='yes'>\
     ");
 
-    this.$(this.el).append(html);
+    $(this.el).append(html);
 
     Backbone.ModelBinding.bind(this, {
       text: 'class',

--- a/spec/javascripts/html5inputConventionBinding.spec.js
+++ b/spec/javascripts/html5inputConventionBinding.spec.js
@@ -14,7 +14,7 @@ describe("HTML5 input convention bindings", function(){
 
   describe("number element binding", function(){
     it("bind view changes to the model's field, by convention of id", function(){
-      var el = this.view.$("#number");
+      var el = $(this.view.el).find("#number");
       el.val("09876");
       el.trigger('change');
 

--- a/spec/javascripts/modelUnbinding.spec.js
+++ b/spec/javascripts/modelUnbinding.spec.js
@@ -20,51 +20,52 @@ describe("model unbinding", function(){
 
     it("should unbind the text box", function(){
       this.model.set({name: "some name change"});
-      var el = this.view.$("#name");
+      var el = $(this.view.el).find("#name");
       expect(el.val()).toEqual("a name");
     });
 
     it("should unbind the textarea", function(){
       this.model.set({bio: "some change to my bio"});
-      var el = this.view.$("#bio");
+      var el = $(this.view.el).find("#bio");
       expect(el.val()).toEqual("a bio");
     });
 
     it("should unbind the password", function(){
       this.model.set({password: "this isn't it"});
-      var el = this.view.$("#password");
+      var el = $(this.view.el).find("#password");
       expect(el.val()).toEqual("it's a secret");
     });
 
     it("should unbind the select box", function(){
       this.model.set({education: "none"});
-      var el = this.view.$("#education");
+      var el = $(this.view.el).find("#education");
       expect(el.val()).toEqual("college");
     });
 
     it("should unbind the radio group", function(){
       this.model.set({graduated: "yes"});
 
-      var elYes = this.view.$("#graduated_yes");
+      var elYes = $(this.view.el).find("#graduated_yes");
       var selected = elYes.attr("checked");
       expect(selected).toBeFalsy();
 
-      var elNo = this.view.$("#graduated_no");
+      var elNo = $(this.view.el).find("#graduated_no");
       var selected = elNo.attr("checked");
       expect(selected).toBeTruthy();
     });
 
     it("should unbind the checkbox", function(){
       this.model.set({drivers_license: false});
-      var el = this.view.$("#drivers_license");
+      var el = $(this.view.el).find("#drivers_license");
       var selected = el.attr("checked");
       expect(selected).toBeTruthy();
     });
 
     it("should unbind the data-bind", function(){
       this.model.set({isValid: false});
-      var el = this.view.$("#clicker");
+      var el = $(this.view.el).find("#clicker");
       var disabled = el.attr("disabled");
+
       expect(disabled).toBeFalsy();
     });
   });

--- a/spec/javascripts/modelUnbinding.spec.js
+++ b/spec/javascripts/modelUnbinding.spec.js
@@ -65,8 +65,11 @@ describe("model unbinding", function(){
       this.model.set({isValid: false});
       var el = $(this.view.el).find("#clicker");
       var disabled = el.attr("disabled");
-
-      expect(disabled).toBeFalsy();
+      if ( window.Zepto ) {
+        expect(el.attr("disabled")).toBe('false');
+      } else {
+        expect(el.attr("disabled")).toBeFalsy();
+      }
     });
   });
   

--- a/spec/javascripts/noConflict.spec.js
+++ b/spec/javascripts/noConflict.spec.js
@@ -16,7 +16,7 @@ describe("Backbone.noConflict", function(){
           <input type='checkbox' id='check' value='yes'>\
           <button id='data' data-bind='disabled isValid'>Click Me!</button>\
         ");
-        this.$(this.el).append(html);
+        $(this.el).append(html);
       }
     });
       

--- a/spec/javascripts/textboxConventionBinding.spec.js
+++ b/spec/javascripts/textboxConventionBinding.spec.js
@@ -41,26 +41,28 @@ describe("textbox convention bindings", function(){
     });
   });
 
-  describe("input with no type specified, binding", function(){
-    beforeEach(function(){
-      this.view.render();
-      this.el = this.view.$("#noType");
-    });
+  if ( window.Zepto == undefined) {
+    describe("input with no type specified, binding", function(){
+      beforeEach(function(){
+        this.view.render();
+        this.el = this.view.$("#noType");
+      });
 
-    it("bind view changes to the model's field, by convention of id", function(){
-      this.el.val("something changed");
-      this.el.trigger('change');
+      it("bind view changes to the model's field, by convention of id", function(){
+        this.el.val("something changed");
+        this.el.trigger('change');
 
-      expect(this.model.get('noType')).toEqual("something changed");
-    });
+        expect(this.model.get('noType')).toEqual("something changed");
+      });
 
-    it("bind model field changes to the form input, by convention of id", function(){
-      this.model.set({noType: "Ian Bailey"});
-      expect(this.el.val()).toEqual("Ian Bailey");
-    });
+      it("bind model field changes to the form input, by convention of id", function(){
+        this.model.set({noType: "Ian Bailey"});
+        expect(this.el.val()).toEqual("Ian Bailey");
+      });
 
-    it("binds the model's value to the form field on render", function(){
-      expect(this.el.val()).toEqual("there is no type");
+      it("binds the model's value to the form field on render", function(){
+        expect(this.el.val()).toEqual("there is no type");
+      });
     });
-  });
+  }
 });


### PR DESCRIPTION
Updated specs to be friendly to Zepto, view.$(selector) does not work in zepto. Had to update the lib a bit more to catch some failing cases for specs. There are a few failed specs, due to zepto limitations.
