### PR TITLE
Don't bind an element when the convention references a non-present attribute

### DIFF
--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -181,29 +181,31 @@ var modelbinding = (function(Backbone, _, $) {
         var elementType = _getElementType(element);
         var attribute_name = config.getBindingValue(element, elementType);
 
-        var modelChange = function(changed_model, val){ element.val(val); };
+        if (attribute_name) {
+          var modelChange = function(changed_model, val){ element.val(val); };
 
-        var setModelValue = function(attr_name, value){
-          var data = {};
-          data[attr_name] = value;
-          model.set(data);
-        };
+          var setModelValue = function(attr_name, value){
+            var data = {};
+            data[attr_name] = value;
+            model.set(data);
+          };
 
-        var elementChange = function(ev){
-          setModelValue(attribute_name, view.$(ev.target).val());
-        };
+          var elementChange = function(ev){
+            setModelValue(attribute_name, view.$(ev.target).val());
+          };
 
-        modelBinder.registerModelBinding(model, attribute_name, modelChange);
-        modelBinder.registerElementBinding(element, elementChange);
+          modelBinder.registerModelBinding(model, attribute_name, modelChange);
+          modelBinder.registerElementBinding(element, elementChange);
 
-        // set the default value on the form, from the model
-        var attr_value = model.get(attribute_name);
-        if (typeof attr_value !== "undefined" && attr_value !== null) {
-          element.val(attr_value);
-        } else {
-          var elVal = element.val();
-          if (elVal){
-            setModelValue(attribute_name, elVal);
+          // set the default value on the form, from the model
+          var attr_value = model.get(attribute_name);
+          if (typeof attr_value !== "undefined" && attr_value !== null) {
+            element.val(attr_value);
+          } else {
+            var elVal = element.val();
+            if (elVal){
+              setModelValue(attribute_name, elVal);
+            }
           }
         }
       });

--- a/spec/javascripts/configurableBindingAttributes.spec.js
+++ b/spec/javascripts/configurableBindingAttributes.spec.js
@@ -30,6 +30,14 @@ describe("configurableBindingAttributes", function(){
       var el = this.view.$(".super_power");
       expect(el.val()).toEqual("mega pooping");
     });
+    
+    it("doesn't bind a field when the convention field isn't on the element", function(){
+      var el = this.view.$("[someAttr=alt_super_power]");
+      el.val("x ray vision");
+      el.trigger('change');
+
+      expect(this.model.get('undefined')).toEqual(undefined);
+    });
   });
   
   describe("radio element binding using configurable attribute", function(){

--- a/spec/javascripts/helpers/sample.backbone.app.js
+++ b/spec/javascripts/helpers/sample.backbone.app.js
@@ -117,6 +117,7 @@ AnotherView = Backbone.View.extend({
   render: function(){
     var html = $("\
       <input type='text' class='super_power' modelAttr='weakness'>\
+      <input type='text' someAttr='alt_super_power'>\
       <select class='education'> \
         <option value='none'>none</option> \
         <option value='grade_school'>i dun learned at grade skool</option> \


### PR DESCRIPTION
In my application, I'm databinding the same DOM tree twice with two different views - I've got a main view, then a table of children that are each bound to their own view.

To allow for repetition, I'm changing the form element convention to use a `data-key` element on the parent, and `data-row-key` on the children. This works fine for binding the children, however when I bind the parent, it binds all of the fields in each child to the `undefined` key of the parent model (since the children don't define the `data-key` attribute).

My patch prevents binding of a field if the resolution of `attribute_name` doesn't turn up anything. It is really only the insertion of the `if()`, but that of course causes a bunch of changes in the indentation of the contained lines. 
