### PR TITLE
Simple change to provide more flexibility for attributes

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,5 +1,0 @@
-if [[ -n "$rvm_path/environments" && -s "$rvm_path/environments/ruby-1.9.2-p180@bb.mb" ]] ; then
-  \. "$rvm_path/environments/ruby-1.9.2-p180@bb.mb"
-else
-  rvm --create  "ruby-1.9.2-p180@bb.mb"
-fi

--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -424,12 +424,12 @@ var modelbinding = (function(Backbone, _, $) {
       val = modelBinding.Configuration.getDataBindSubst(attr, val);
       switch(attr){
         case "html":
-          if (val && (typeof val !== 'undefined') && (val !== null)) {
+          if ((typeof val !== 'undefined') && (val !== null)) {
               element.html(val);
           }
           break;
         case "text":
-          if (val && typeof val !== 'undefined' && val !== null) {
+          if ((typeof val !== 'undefined') && (val !== null)) {
               element.text(val);
           }
           break;

--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -98,15 +98,15 @@ var modelbinding = (function(Backbone, _, $) {
       }
     }
 
-    this.getBindingAttr = function(type){ 
-      return this.bindingAttrConfig[type]; 
-    };
+  };
 
-    this.getBindingValue = function(element, type){
-      var bindingAttr = this.getBindingAttr(type);
-      return element.attr(bindingAttr);
-    };
+  modelBinding.Configuration.prototype.getBindingAttr = function(type){
+    return this.bindingAttrConfig[type];
+  };
 
+  modelBinding.Configuration.prototype.getBindingValue = function(element, type){
+    var bindingAttr = this.getBindingAttr(type);
+    return element.attr(bindingAttr);
   };
 
   modelBinding.Configuration.bindindAttrConfig = {

--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -424,12 +424,12 @@ var modelbinding = (function(Backbone, _, $) {
       val = modelBinding.Configuration.getDataBindSubst(attr, val);
       switch(attr){
         case "html":
-          if (val) {
+          if (val && (typeof val !== 'undefined') && (val !== null)) {
               element.html(val);
           }
           break;
         case "text":
-          if (val) {
+          if (val && typeof val !== 'undefined' && val !== null) {
               element.text(val);
           }
           break;

--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -424,10 +424,14 @@ var modelbinding = (function(Backbone, _, $) {
       val = modelBinding.Configuration.getDataBindSubst(attr, val);
       switch(attr){
         case "html":
-          element.html(val);
+          if (val) {
+              element.html(val);
+          }
           break;
         case "text":
-          element.text(val);
+          if (val) {
+              element.text(val);
+          }
           break;
         case "enabled":
           element.attr("disabled", !val);


### PR DESCRIPTION
This is a simple change that could be the start of  something larger. I had seen others talking about rails integration and the object[attr] names there.  Rather than a major refactor, this small fix allowed me to monkey patch by overriding Configuration.getBindingValue as so:

``` coffeescript
Backbone.ModelBinding.Configuration.prototype.getBindingValue = (element, type) ->
  bindingAttr = this.getBindingAttr(type)
  # looks for the railsish object[attribute] style
  attributeRegex = /^[^\[]+\[(.+)\]$/
  attributeValue = element.attr(bindingAttr)
  if attributeRegex.test(attributeValue)
    return attributeValue.match(attributeRegex)[1]
  else
    return attributeValue
```

To be clear: the above change is _not_ in my commit - just changing where functions are assigned. It should save a little memory on every config instance too.
