### PR TITLE
Enable Nested Model Binding, Restrict Field Binding

### DIFF
--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -92,7 +92,7 @@ var modelbinding = (function(Backbone, _, $) {
       var attr = this.bindingAttrConfig.all;
       delete this.bindingAttrConfig.all;
       for (var inputType in this.bindingAttrConfig){
-        if (this.bindingAttrConfig.hasOwnProperty(inputType)){
+        if (this.bindingAttrConfig.hasOwnProperty(inputType) && inputType !== 'shouldBindToEl'){
           this.bindingAttrConfig[inputType] = attr;
         }
       }
@@ -107,6 +107,14 @@ var modelbinding = (function(Backbone, _, $) {
       return element.attr(bindingAttr);
     };
 
+    this.shouldBindToEl = function(el){
+      if(this.bindingAttrConfig.shouldBindToEl){
+        return this.bindingAttrConfig.shouldBindToEl(el);
+      }
+      else {
+        return true;
+      }
+    }
   };
 
   modelBinding.Configuration.bindindAttrConfig = {
@@ -178,32 +186,34 @@ var modelbinding = (function(Backbone, _, $) {
 
       view.$(selector).each(function(index){
         var element = view.$(this);
-        var elementType = _getElementType(element);
-        var attribute_name = config.getBindingValue(element, elementType);
 
-        var modelChange = function(changed_model, val){ element.val(val); };
+        if(config.shouldBindToEl(element)){
+          var elementType = _getElementType(element);
+          var attribute_name = config.getBindingValue(element, elementType);
+          var modelChange = function(changed_model, val){ element.val(val); };
 
-        var setModelValue = function(attr_name, value){
-          var data = {};
-          data[attr_name] = value;
-          model.set(data);
-        };
+          var setModelValue = function(attr_name, value){
+            var data = {};
+            data[attr_name] = value;
+            model.set(data);
+          };
 
-        var elementChange = function(ev){
-          setModelValue(attribute_name, view.$(ev.target).val());
-        };
+          var elementChange = function(ev){
+            setModelValue(attribute_name, view.$(ev.target).val());
+          };
 
-        modelBinder.registerModelBinding(model, attribute_name, modelChange);
-        modelBinder.registerElementBinding(element, elementChange);
+          modelBinder.registerModelBinding(model, attribute_name, modelChange);
+          modelBinder.registerElementBinding(element, elementChange);
 
-        // set the default value on the form, from the model
-        var attr_value = model.get(attribute_name);
-        if (typeof attr_value !== "undefined" && attr_value !== null) {
-          element.val(attr_value);
-        } else {
-          var elVal = element.val();
-          if (elVal){
-            setModelValue(attribute_name, elVal);
+          // set the default value on the form, from the model
+          var attr_value = model.get(attribute_name);
+          if (typeof attr_value !== "undefined" && attr_value !== null) {
+            element.val(attr_value);
+          } else {
+            var elVal = element.val();
+            if (elVal){
+              setModelValue(attribute_name, elVal);
+            }
           }
         }
       });
@@ -223,38 +233,40 @@ var modelbinding = (function(Backbone, _, $) {
 
       view.$(selector).each(function(index){
         var element = view.$(this);
-        var attribute_name = config.getBindingValue(element, 'select');
 
-        var modelChange = function(changed_model, val){ element.val(val); };
+        if(config.shouldBindToEl(element)){
+          var attribute_name = config.getBindingValue(element, 'select');
+          var modelChange = function(changed_model, val){ element.val(val); };
 
-        var setModelValue = function(attr, val, text){
-          var data = {};
-          data[attr] = val;
-          data[attr + "_text"] = text;
-          model.set(data);
-        };
+          var setModelValue = function(attr, val, text){
+            var data = {};
+            data[attr] = val;
+            data[attr + "_text"] = text;
+            model.set(data);
+          };
 
-        var elementChange = function(ev){
-          var targetEl = view.$(ev.target);
-          var value = targetEl.val();
-          var text = targetEl.find(":selected").text();
-          setModelValue(attribute_name, value, text);
-        };
+          var elementChange = function(ev){
+            var targetEl = view.$(ev.target);
+            var value = targetEl.val();
+            var text = targetEl.find(":selected").text();
+            setModelValue(attribute_name, value, text);
+          };
 
-        modelBinder.registerModelBinding(model, attribute_name, modelChange);
-        modelBinder.registerElementBinding(element, elementChange);
+          modelBinder.registerModelBinding(model, attribute_name, modelChange);
+          modelBinder.registerElementBinding(element, elementChange);
 
-        // set the default value on the form, from the model
-        var attr_value = model.get(attribute_name);
-        if (typeof attr_value !== "undefined" && attr_value !== null) {
-          element.val(attr_value);
-        } 
+          // set the default value on the form, from the model
+          var attr_value = model.get(attribute_name);
+          if (typeof attr_value !== "undefined" && attr_value !== null) {
+            element.val(attr_value);
+          }
 
-        // set the model to the form's value if there is no model value
-        if (element.val() != attr_value) {
-          var value = element.val();
-          var text = element.find(":selected").text();
-          setModelValue(attribute_name, value, text);
+          // set the model to the form's value if there is no model value
+          if (element.val() != attr_value) {
+            var value = element.val();
+            var text = element.find(":selected").text();
+            setModelValue(attribute_name, value, text);
+          }
         }
       });
     };
@@ -275,47 +287,51 @@ var modelbinding = (function(Backbone, _, $) {
       view.$(selector).each(function(index){
         var element = view.$(this);
 
-        var group_name = config.getBindingValue(element, 'radio');
-        if (!foundElements[group_name]) {
-          foundElements[group_name] = true;
-          var bindingAttr = config.getBindingAttr('radio');
+        if(config.shouldBindToEl(element)){
+          var group_name = config.getBindingValue(element, 'radio');
+          if (!foundElements[group_name]) {
+            foundElements[group_name] = true;
+            var bindingAttr = config.getBindingAttr('radio');
 
-          var modelChange = function(model, val){
-            var value_selector = "input[type=radio][" + bindingAttr + "='" + group_name + "'][value='" + val + "']";
-            view.$(value_selector).attr("checked", "checked");
-          };
-          modelBinder.registerModelBinding(model, group_name, modelChange);
+            var modelChange = function(model, val){
+              var value_selector = "input[type=radio][" + bindingAttr + "='" + group_name + "'][value='" + val + "']";
+              view.$(value_selector).attr("checked", "checked");
+            };
+            modelBinder.registerModelBinding(model, group_name, modelChange);
 
-          var setModelValue = function(attr, val){
-            var data = {};
-            data[attr] = val;
-            model.set(data);
-          };
+            var setModelValue = function(attr, val){
+              var data = {};
+              data[attr] = val;
+              model.set(data);
+            };
 
-          // bind the form changes to the model
-          var elementChange = function(ev){
-            var element = view.$(ev.currentTarget);
-            if (element.is(":checked")){
-              setModelValue(group_name, element.val());
+            // bind the form changes to the model
+            var elementChange = function(ev){
+              var element = view.$(ev.currentTarget);
+              if (element.is(":checked")){
+                setModelValue(group_name, element.val());
+              }
+            };
+
+            var group_selector = "input[type=radio][" + bindingAttr + "='" + group_name + "']";
+            view.$(group_selector).each(function(){
+              var groupEl = $(this);
+              if(!config.bindingAttrConfig.shouldBindToEl || config.bindingAttrConfig.shouldBindToEl(groupEl)){
+                modelBinder.registerElementBinding(groupEl, elementChange);
+              }
+            });
+
+            var attr_value = model.get(group_name);
+            if (typeof attr_value !== "undefined" && attr_value !== null) {
+              // set the default value on the form, from the model
+              var value_selector = "input[type=radio][" + bindingAttr + "='" + group_name + "'][value='" + attr_value + "']";
+              view.$(value_selector).attr("checked", "checked");
+            } else {
+              // set the model to the currently selected radio button
+              var value_selector = "input[type=radio][" + bindingAttr + "='" + group_name + "']:checked";
+              var value = view.$(value_selector).val();
+              setModelValue(group_name, value);
             }
-          };
-
-          var group_selector = "input[type=radio][" + bindingAttr + "='" + group_name + "']";
-          view.$(group_selector).each(function(){
-            var groupEl = $(this);
-            modelBinder.registerElementBinding(groupEl, elementChange);
-          });
-
-          var attr_value = model.get(group_name);
-          if (typeof attr_value !== "undefined" && attr_value !== null) {
-            // set the default value on the form, from the model
-            var value_selector = "input[type=radio][" + bindingAttr + "='" + group_name + "'][value='" + attr_value + "']";
-            view.$(value_selector).attr("checked", "checked");
-          } else {
-            // set the model to the currently selected radio button
-            var value_selector = "input[type=radio][" + bindingAttr + "='" + group_name + "']:checked";
-            var value = view.$(value_selector).val();
-            setModelValue(group_name, value);
           }
         }
       });
@@ -335,47 +351,51 @@ var modelbinding = (function(Backbone, _, $) {
 
       view.$(selector).each(function(index){
         var element = view.$(this);
-        var bindingAttr = config.getBindingAttr('checkbox');
-        var attribute_name = config.getBindingValue(element, 'checkbox');
 
-        var modelChange = function(model, val){
-          if (val){
-            element.attr("checked", "checked");
+        if(config.shouldBindToEl(element)){
+
+          var bindingAttr = config.getBindingAttr('checkbox');
+          var attribute_name = config.getBindingValue(element, 'checkbox');
+
+          var modelChange = function(model, val){
+            if (val){
+              element.attr("checked", "checked");
+            }
+            else{
+              element.removeAttr("checked");
+            }
+          };
+
+          var setModelValue = function(attr_name, value){
+            var data = {};
+            data[attr_name] = value;
+            model.set(data);
+          };
+
+          var elementChange = function(ev){
+            var changedElement = view.$(ev.target);
+            var checked = changedElement.is(":checked")? true : false;
+            setModelValue(attribute_name, checked);
+          };
+
+          modelBinder.registerModelBinding(model, attribute_name, modelChange);
+          modelBinder.registerElementBinding(element, elementChange);
+
+          var attr_exists = model.attributes.hasOwnProperty(attribute_name);
+          if (attr_exists) {
+            // set the default value on the form, from the model
+            var attr_value = model.get(attribute_name);
+            if (typeof attr_value !== "undefined" && attr_value !== null && attr_value != false) {
+              element.attr("checked", "checked");
+            }
+            else{
+              element.removeAttr("checked");
+            }
+          } else {
+            // bind the form's value to the model
+            var checked = element.is(":checked")? true : false;
+            setModelValue(attribute_name, checked);
           }
-          else{
-            element.removeAttr("checked");
-          }
-        };
-
-        var setModelValue = function(attr_name, value){
-          var data = {};
-          data[attr_name] = value;
-          model.set(data);
-        };
-
-        var elementChange = function(ev){
-          var changedElement = view.$(ev.target);
-          var checked = changedElement.is(":checked")? true : false;
-          setModelValue(attribute_name, checked);
-        };
-
-        modelBinder.registerModelBinding(model, attribute_name, modelChange);
-        modelBinder.registerElementBinding(element, elementChange);
-
-        var attr_exists = model.attributes.hasOwnProperty(attribute_name);
-        if (attr_exists) {
-          // set the default value on the form, from the model
-          var attr_value = model.get(attribute_name);
-          if (typeof attr_value !== "undefined" && attr_value !== null && attr_value != false) {
-            element.attr("checked", "checked");
-          }
-          else{
-            element.removeAttr("checked");
-          }
-        } else {
-          // bind the form's value to the model
-          var checked = element.is(":checked")? true : false;
-          setModelValue(attribute_name, checked);
         }
       });
     };
@@ -490,15 +510,17 @@ var modelbinding = (function(Backbone, _, $) {
 
       view.$(selector).each(function(index){
         var element = view.$(this);
-        var databindList = splitBindingAttr(element);
 
-        _.each(databindList, function(databind){
-          var eventConfig = getEventConfiguration(element, databind);
-          modelBinder.registerDataBinding(model, eventConfig.name, eventConfig.callback);
-          // set default on data-bind element
-          setOnElement(element, databind.elementAttr, model.get(databind.modelAttr));
-        });
+        if(config.shouldBindToEl(element)){
+          var databindList = splitBindingAttr(element);
 
+          _.each(databindList, function(databind){
+            var eventConfig = getEventConfiguration(element, databind);
+            modelBinder.registerDataBinding(model, eventConfig.name, eventConfig.callback);
+            // set default on data-bind element
+            setOnElement(element, databind.elementAttr, model.get(databind.modelAttr));
+          });
+        }
       });
     };
 

--- a/spec/SpecRunner.html
+++ b/spec/SpecRunner.html
@@ -42,7 +42,7 @@
 
   <!-- include source files here... -->
   <script type="text/javascript" src="../public/javascripts/underscore.js"></script>
-  <script type="text/javascript" src="../public/javascripts/jquery-1.6.2.js"></script>
+  <script type="text/javascript" src="../public/javascripts/jquery.js"></script>
   <script type="text/javascript" src="../public/javascripts/backbone.js"></script>
   <script type="text/javascript" src="../backbone.modelbinding.js"></script>
 
@@ -68,6 +68,8 @@
   <script type="text/javascript" src="javascripts/selectboxConventionBindings.spec.js"></script>
   <script type="text/javascript" src="javascripts/textareaConventionBinding.spec.js"></script>
   <script type="text/javascript" src="javascripts/textboxConventionBinding.spec.js"></script>
+  <script type="text/javascript" src="javascripts/nestedModelBinding.spec.js"></script>
+  <script type="text/javascript" src="javascripts/nestedModelBindingByName.spec.js"></script>
 
 </head>
   <body>

--- a/spec/javascripts/helpers/sample.backbone.app.js
+++ b/spec/javascripts/helpers/sample.backbone.app.js
@@ -138,7 +138,172 @@ AnotherView = Backbone.View.extend({
       password: 'class',
       radio: 'class',
       select: 'class',
-      checkbox: 'class',
+      checkbox: 'class'
     });
   }
 });
+
+NestedInnerView = Backbone.View.extend({
+  id: 'innerDiv',
+
+  render: function(){
+    var html = $("\
+      <input type='text' id='innerText'>\
+      <input type='text' id='sharedText'>\
+      <select id='innerSelect'> \
+        <option value='none'>none</option> \
+        <option value='grade_school'>i dun learned at grade skool</option> \
+        <option value='high school'>high school</option> \
+        <option value='college'>college</option> \
+        <option value='graduate'>graduate</option> \
+      </select> \
+      <select id='sharedSelect'> \
+        <option value='none'>none</option> \
+        <option value='grade_school'>i dun learned at grade skool</option> \
+        <option value='high school'>high school</option> \
+        <option value='college'>college</option> \
+        <option value='graduate'>graduate</option> \
+      </select> \
+      <input type='radio' id='graduated_yes' name='innerRadio' value='yes'>\
+      <input type='radio' id='graduated_no' name='innerRadio' value='no'>\
+      <input type='radio' id='graduated_maybe' name='innerRadio' value='maybe'>\
+      <input type='radio' id='graduated_yes' name='sharedRadio' value='yes'>\
+      <input type='radio' id='graduated_no' name='sharedRadio' value='no'>\
+      <input type='radio' id='graduated_maybe' name='sharedRadio' value='maybe'>\
+      <input type='checkbox' id='innerCheckbox' value='yes'>\
+      <input type='checkbox' id='sharedCheckbox' value='yes'>\
+    ");
+    this.$el.append(html);
+  }
+});
+
+NestedOuterView = Backbone.View.extend({
+  initialize: function(){
+    this.innerView = new NestedInnerView({model: this.model.get('innerModel')});
+  },
+
+  render: function(){
+    var html = $("\
+      <div id='outerDiv'>\
+        <input type='text' id='outerText'>\
+        <input type='text' id='sharedText'>\
+        <select id='outerSelect'> \
+          <option value='none'>none</option> \
+          <option value='grade_school'>i dun learned at grade skool</option> \
+          <option value='high school'>high school</option> \
+          <option value='college'>college</option> \
+          <option value='graduate'>graduate</option> \
+        </select> \
+        <select id='sharedSelect'> \
+          <option value='none'>none</option> \
+          <option value='grade_school'>i dun learned at grade skool</option> \
+          <option value='high school'>high school</option> \
+          <option value='college'>college</option> \
+          <option value='graduate'>graduate</option> \
+        </select> \
+        <input type='radio' id='graduated_yes' name='outerRadio' value='yes'>\
+        <input type='radio' id='graduated_no' name='outerRadio' value='no'>\
+        <input type='radio' id='graduated_maybe' name='outerRadio' value='maybe'>\
+        <input type='radio' id='graduated_yes' name='sharedRadio' value='yes'>\
+        <input type='radio' id='graduated_no' name='sharedRadio' value='no'>\
+        <input type='radio' id='graduated_maybe' name='sharedRadio' value='maybe'>\
+        <input type='checkbox' id='outerCheckbox' value='yes'>\
+        <input type='checkbox' id='sharedCheckbox' value='yes'>\
+      </div>\
+    ");
+
+    this.$el.append(html);
+    this.innerView.render();
+    this.$('#outerDiv').append(this.innerView.$el);
+
+    var outerViewBindingAttributeConfig = {shouldBindToEl: function(el){return el.parent().attr('id') === 'outerDiv';}};
+    var innerViewBindingAttributeConfig = {shouldBindToEl: function(el){return el.parent().attr('id') === 'innerDiv';}};
+
+    Backbone.ModelBinding.bind(this, outerViewBindingAttributeConfig);
+    Backbone.ModelBinding.bind(this.innerView, innerViewBindingAttributeConfig);
+  }
+});
+
+NestedInnerViewWithNameAttributes = Backbone.View.extend({
+  id: 'innerDiv',
+
+  render: function(){
+    var html = $("\
+      <input type='text' name='innerText'>\
+      <input type='text' name='sharedText'>\
+      <select name='innerSelect'> \
+        <option value='none'>none</option> \
+        <option value='grade_school'>i dun learned at grade skool</option> \
+        <option value='high school'>high school</option> \
+        <option value='college'>college</option> \
+        <option value='graduate'>graduate</option> \
+      </select> \
+      <select name='sharedSelect'> \
+        <option value='none'>none</option> \
+        <option value='grade_school'>i dun learned at grade skool</option> \
+        <option value='high school'>high school</option> \
+        <option value='college'>college</option> \
+        <option value='graduate'>graduate</option> \
+      </select> \
+      <input type='radio' id='graduated_yes' name='innerRadio' value='yes'>\
+      <input type='radio' id='graduated_no' name='innerRadio' value='no'>\
+      <input type='radio' id='graduated_maybe' name='innerRadio' value='maybe'>\
+      <input type='radio' id='graduated_yes' name='sharedRadio' value='yes'>\
+      <input type='radio' id='graduated_no' name='sharedRadio' value='no'>\
+      <input type='radio' id='graduated_maybe' name='sharedRadio' value='maybe'>\
+      <input type='checkbox' name='innerCheckbox' value='yes'>\
+      <input type='checkbox' name='sharedCheckbox' value='yes'>\
+    ");
+    this.$el.append(html);
+  }
+});
+
+NestedOuterViewWithNameAttributes = Backbone.View.extend({
+  initialize: function(){
+    this.innerView = new NestedInnerViewWithNameAttributes({model: this.model.get('innerModel')});
+  },
+
+  render: function(){
+    var html = $("\
+      <div id='outerDiv'>\
+        <input type='text' name='outerText'>\
+        <input type='text' name='sharedText'>\
+        <select name='outerSelect'> \
+          <option value='none'>none</option> \
+          <option value='grade_school'>i dun learned at grade skool</option> \
+          <option value='high school'>high school</option> \
+          <option value='college'>college</option> \
+          <option value='graduate'>graduate</option> \
+        </select> \
+        <select name='sharedSelect'> \
+          <option value='none'>none</option> \
+          <option value='grade_school'>i dun learned at grade skool</option> \
+          <option value='high school'>high school</option> \
+          <option value='college'>college</option> \
+          <option value='graduate'>graduate</option> \
+        </select> \
+        <input type='radio' id='graduated_yes' name='outerRadio' value='yes'>\
+        <input type='radio' id='graduated_no' name='outerRadio' value='no'>\
+        <input type='radio' id='graduated_maybe' name='outerRadio' value='maybe'>\
+        <input type='radio' id='graduated_yes' name='sharedRadio' value='yes'>\
+        <input type='radio' id='graduated_no' name='sharedRadio' value='no'>\
+        <input type='radio' id='graduated_maybe' name='sharedRadio' value='maybe'>\
+        <input type='checkbox' name='outerCheckbox' value='yes'>\
+        <input type='checkbox' name='sharedCheckbox' value='yes'>\
+      </div>\
+    ");
+
+    this.$el.append(html);
+    this.innerView.render();
+    this.$('#outerDiv').append(this.innerView.$el);
+
+    var outerViewBindingAttributeConfig = {all: "name",
+                                            shouldBindToEl: function(el){return el.parent().attr('id') === 'outerDiv';}};
+    var innerViewBindingAttributeConfig = {all: "name",
+                                            shouldBindToEl: function(el){return el.parent().attr('id') === 'innerDiv';}};
+
+    Backbone.ModelBinding.bind(this, outerViewBindingAttributeConfig);
+    Backbone.ModelBinding.bind(this.innerView, innerViewBindingAttributeConfig);
+  }
+});
+

--- a/spec/javascripts/nestedModelBinding.spec.js
+++ b/spec/javascripts/nestedModelBinding.spec.js
@@ -1,0 +1,229 @@
+describe("data-bind nested views", function(){
+  beforeEach(function(){
+    this.outerModel = new AModel({name: "outerModel"});
+    this.innerModel = new AModel({name: "innerModel"});
+    this.outerModel.set({innerModel: this.innerModel});
+
+    this.outerView = new NestedOuterView({model: this.outerModel});
+    this.outerView.render();
+    this.innerView = this.outerView.innerView;
+  });
+
+  describe ("when binding to unique fields in an inner view", function(){
+    it("the inner text should be updated", function(){
+      $("#innerText", this.innerView.$el).val("batman");
+      $("#innerText", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("innerText")).toBe("batman");
+    });
+
+    it("the outer text should not be updated", function(){
+      $("#innerText", this.innerView.$el).val("robin");
+      $("#innerText", this.innerView.$el).trigger("change");
+      expect(this.outerModel.get("innerText")).toBe(undefined);
+    });
+
+    it("the inner select should be updated", function(){
+      $("#innerSelect", this.innerView.$el).val("college");
+      $("#innerSelect", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("innerSelect")).toBe("college");
+    });
+
+    it("the outer select should not be updated", function(){
+      $("#innerSelect", this.innerView.$el).val("graduate");
+      $("#innerSelect", this.innerView.$el).trigger("change");
+      expect(this.outerModel.get("innerSelect")).toBe(undefined);
+    });
+
+    it("the inner radio should be updated", function(){
+      $("#graduated_maybe", this.innerView.$el).attr("checked", "checked");
+      $("#graduated_maybe", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("innerRadio")).toBe("maybe");
+    });
+
+    it("the outer radio should not be updated", function(){
+      $("#graduated_yes", this.innerView.$el).attr("checked", "checked");
+      $("#graduated_yes", this.innerView.$el).trigger("change");
+      expect(this.outerModel.get("innerRadio")).toBe(undefined);
+    });
+
+    it("the inner checkbox should be updated", function(){
+      $("#innerCheckbox", this.innerView.$el).removeAttr("checked");
+      $("#innerCheckbox", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("innerCheckbox")).toBe(false);
+      $("#innerCheckbox", this.innerView.$el).attr("checked", "checked");
+      $("#innerCheckbox", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("innerCheckbox")).toBe(true);
+    });
+
+    it("the outer checkbox should not be updated", function(){
+      $("#innerCheckbox", this.innerView.$el).removeAttr("checked");
+      $("#innerCheckbox", this.innerView.$el).trigger("change");
+      $("#innerCheckbox", this.innerView.$el).attr("checked", "checked");
+      $("#innerCheckbox", this.innerView.$el).trigger("change");
+      expect(this.outerModel.get("innerCheckbox")).toBe(undefined);
+    });
+  });
+
+  describe ("when binding to unique fields in an outer view", function(){
+    it("the outer text should be updated", function(){
+      $("#outerText", this.outerView.$el).val("joker");
+      $("#outerText", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("outerText")).toBe("joker");
+    });
+
+    it("the inner text should not be updated", function(){
+      $("#outerText", this.outerView.$el).val("penguin");
+      $("#outerText", this.outerView.$el).trigger("change");
+      expect(this.innerModel.get("outerText")).toBe(undefined);
+    });
+
+    it("the outer select should be updated", function(){
+      $("#outerSelect", this.outerView.$el).val("grade_school");
+      $("#outerSelect", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("outerSelect")).toBe("grade_school");
+    });
+
+    it("the inner select should not be updated", function(){
+      $("#outerSelect", this.outerView.$el).val("none");
+      $("#outerSelect", this.outerView.$el).trigger("change");
+      expect(this.innerModel.get("outerSelect")).toBe(undefined);
+    });
+
+    it("the outer radio should be updated", function(){
+      $("#graduated_maybe", this.outerView.$el).attr("checked", "checked");
+      $("#graduated_maybe", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("outerRadio")).toBe("maybe");
+    });
+
+    it("the inner radio should not be updated", function(){
+      $("#graduated_yes", this.outerView.$el).attr("checked", "checked");
+      $("#graduated_yes", this.outerView.$el).trigger("change");
+      expect(this.innerModel.get("outerRadio")).toBe(undefined);
+    });
+
+    it("the outer checkbox should be updated", function(){
+      $("#outerCheckbox", this.outerView.$el).removeAttr("checked");
+      $("#outerCheckbox", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("outerCheckbox")).toBe(false);
+      $("#outerCheckbox", this.outerView.$el).attr("checked", "checked");
+      $("#outerCheckbox", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("outerCheckbox")).toBe(true);
+    });
+
+    it("the inner checkbox should not be updated", function(){
+      $("#outerCheckbox", this.outerView.$el).removeAttr("checked");
+      $("#outerCheckbox", this.outerView.$el).trigger("change");
+      $("#outerCheckbox", this.outerView.$el).attr("checked", "checked");
+      $("#outerCheckbox", this.outerView.$el).trigger("change");
+      expect(this.innerModel.get("outerCheckbox")).toBe(undefined);
+    });
+  });
+
+  describe("when binding to shared id fields in an inner view", function () {
+    it("the inner text should be updated", function () {
+      $("#sharedText", this.innerView.$el).val("batman");
+      $("#sharedText", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedText")).toBe("batman");
+    });
+
+    it("the outer text should not be updated", function () {
+      $("#sharedText", this.innerView.$el).val("robin");
+      $("#sharedText", this.innerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedText")).toBe(undefined);
+    });
+
+    it("the inner select should be updated", function () {
+      $("#sharedSelect", this.innerView.$el).val("college");
+      $("#sharedSelect", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedSelect")).toBe("college");
+    });
+
+    it("the outer select should not be updated", function () {
+      $("#sharedSelect", this.innerView.$el).val("graduate");
+      $("#sharedSelect", this.innerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedSelect")).toBe("none");
+    });
+
+    it("the inner radio should be updated", function () {
+      $("#graduated_maybe[name=sharedRadio]", this.innerView.$el).attr("checked", "checked");
+      $("#graduated_maybe[name=sharedRadio]", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedRadio")).toBe("maybe");
+    });
+
+    it("the outer radio should not be updated", function () {
+      $("#graduated_yes[name=sharedRadio]", this.innerView.$el).attr("checked", "checked");
+      $("#graduated_yes[name=sharedRadio]", this.innerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedRadio")).toBe(undefined);
+    });
+
+    it("the inner checkbox should be updated", function () {
+      $("#sharedCheckbox", this.innerView.$el).removeAttr("checked");
+      $("#sharedCheckbox", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedCheckbox")).toBe(false);
+      $("#sharedCheckbox", this.innerView.$el).attr("checked", "checked");
+      $("#sharedCheckbox", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedCheckbox")).toBe(true);
+    });
+
+    it("the outer checkbox should not be updated", function () {
+      $("#sharedCheckbox", this.innerView.$el).removeAttr("checked");
+      $("#sharedCheckbox", this.innerView.$el).trigger("change");
+      $("#sharedCheckbox", this.innerView.$el).attr("checked", "checked");
+      $("#sharedCheckbox", this.innerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedCheckbox")).toBe(false);
+    });
+  });
+
+  describe("when binding to shared id fields in an outer view", function () {
+    it("the outer text should be updated", function () {
+      $("#sharedText:first", this.outerView.$el).val("batman");
+      $("#sharedText", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedText")).toBe("batman");
+    });
+
+    it("the inner text should not be updated", function () {
+      $("#sharedText:first", this.outerView.$el).val("robin");
+      $("#sharedText:first", this.outerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedText")).toBe(undefined);
+    });
+
+    it("the outer select should be updated", function () {
+      $("#sharedSelect:first", this.outerView.$el).val("college");
+      $("#sharedSelect:first", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedSelect")).toBe("college");
+    });
+
+    it("the inner select should not be updated", function () {
+      $("#sharedSelect:first", this.outerView.$el).val("graduate");
+      $("#sharedSelect:first", this.outerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedSelect")).toBe("none");
+    });
+
+    it("the outer radio should be updated", function () {
+      $("#graduated_maybe[name=sharedRadio]:first", this.outerView.$el).attr("checked", "checked");
+      $("#graduated_maybe[name=sharedRadio]:first", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedRadio")).toBe("maybe");
+    });
+
+    it("the inner radio should not be updated", function () {
+      $("#graduated_yes[name=sharedRadio]:first", this.outerView.$el).attr("checked", "checked");
+      $("#graduated_yes[name=sharedRadio]:first", this.outerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedRadio")).toBe(undefined);
+    });
+
+    it("the outer checkbox should be updated", function () {
+      $("#sharedCheckbox:first", this.outerView.$el).removeAttr("checked");
+      $("#sharedCheckbox:first", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedCheckbox")).toBe(false);
+      $("#sharedCheckbox:first", this.outerView.$el).attr("checked", "checked");
+      $("#sharedCheckbox:first", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedCheckbox")).toBe(true);
+    });
+
+    it("the inner checkbox should not be updated", function () {
+      $("#sharedCheckbox:first", this.outerView.$el).attr("checked", "checked");
+      $("#sharedCheckbox:first", this.outerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedCheckbox")).toBe(false);
+    });
+  });
+});

--- a/spec/javascripts/nestedModelBindingByName.spec.js
+++ b/spec/javascripts/nestedModelBindingByName.spec.js
@@ -1,0 +1,232 @@
+// Some projects only bind by name, especially where nested views are prevalent
+// so ensuring that nested views that rely on the name attribute is important
+
+describe("data-bind nested views", function(){
+  beforeEach(function(){
+    this.outerModel = new AModel({name: "outerModel"});
+    this.innerModel = new AModel({name: "innerModel"});
+    this.outerModel.set({innerModel: this.innerModel});
+
+    this.outerView = new NestedOuterViewWithNameAttributes({model: this.outerModel});
+    this.outerView.render();
+    this.innerView = this.outerView.innerView;
+  });
+
+  describe ("when binding to unique fields in an inner view", function(){
+    it("the inner text should be updated", function(){
+      $("[name=innerText]", this.innerView.$el).val("batman");
+      $("[name=innerText]", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("innerText")).toBe("batman");
+    });
+
+    it("the outer text should not be updated", function(){
+      $("[name=innerText]", this.innerView.$el).val("robin");
+      $("[name=innerText]", this.innerView.$el).trigger("change");
+      expect(this.outerModel.get("innerText")).toBe(undefined);
+    });
+
+    it("the inner select should be updated", function(){
+      $("[name=innerSelect]", this.innerView.$el).val("college");
+      $("[name=innerSelect]", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("innerSelect")).toBe("college");
+    });
+
+    it("the outer select should not be updated", function(){
+      $("[name=innerSelect]", this.innerView.$el).val("graduate");
+      $("[name=innerSelect]", this.innerView.$el).trigger("change");
+      expect(this.outerModel.get("innerSelect")).toBe(undefined);
+    });
+
+    it("the inner radio should be updated", function(){
+      $("#graduated_maybe", this.innerView.$el).attr("checked", "checked");
+      $("#graduated_maybe", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("innerRadio")).toBe("maybe");
+    });
+
+    it("the outer radio should not be updated", function(){
+      $("#graduated_yes", this.innerView.$el).attr("checked", "checked");
+      $("#graduated_yes", this.innerView.$el).trigger("change");
+      expect(this.outerModel.get("innerRadio")).toBe(undefined);
+    });
+
+    it("the inner checkbox should be updated", function(){
+      $("[name=innerCheckbox]", this.innerView.$el).removeAttr("checked");
+      $("[name=innerCheckbox]", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("innerCheckbox")).toBe(false);
+      $("[name=innerCheckbox]", this.innerView.$el).attr("checked", "checked");
+      $("[name=innerCheckbox]", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("innerCheckbox")).toBe(true);
+    });
+
+    it("the outer checkbox should not be updated", function(){
+      $("[name=innerCheckbox]", this.innerView.$el).removeAttr("checked");
+      $("[name=innerCheckbox]", this.innerView.$el).trigger("change");
+      $("[name=innerCheckbox]", this.innerView.$el).attr("checked", "checked");
+      $("[name=innerCheckbox]", this.innerView.$el).trigger("change");
+      expect(this.outerModel.get("innerCheckbox")).toBe(undefined);
+    });
+  });
+
+  describe ("when binding to unique fields in an outer view", function(){
+    it("the outer text should be updated", function(){
+      $("[name=outerText]", this.outerView.$el).val("joker");
+      $("[name=outerText]", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("outerText")).toBe("joker");
+    });
+
+    it("the inner text should not be updated", function(){
+      $("[name=outerText]", this.outerView.$el).val("penguin");
+      $("[name=outerText]", this.outerView.$el).trigger("change");
+      expect(this.innerModel.get("outerText")).toBe(undefined);
+    });
+
+    it("the outer select should be updated", function(){
+      $("[name=outerSelect]", this.outerView.$el).val("grade_school");
+      $("[name=outerSelect]", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("outerSelect")).toBe("grade_school");
+    });
+
+    it("the inner select should not be updated", function(){
+      $("[name=outerSelect]", this.outerView.$el).val("none");
+      $("[name=outerSelect]", this.outerView.$el).trigger("change");
+      expect(this.innerModel.get("outerSelect")).toBe(undefined);
+    });
+
+    it("the outer radio should be updated", function(){
+      $("#graduated_maybe", this.outerView.$el).attr("checked", "checked");
+      $("#graduated_maybe", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("outerRadio")).toBe("maybe");
+    });
+
+    it("the inner radio should not be updated", function(){
+      $("#graduated_yes", this.outerView.$el).attr("checked", "checked");
+      $("#graduated_yes", this.outerView.$el).trigger("change");
+      expect(this.innerModel.get("outerRadio")).toBe(undefined);
+    });
+
+    it("the outer checkbox should be updated", function(){
+      $("[name=outerCheckbox]", this.outerView.$el).removeAttr("checked");
+      $("[name=outerCheckbox]", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("outerCheckbox")).toBe(false);
+      $("[name=outerCheckbox]", this.outerView.$el).attr("checked", "checked");
+      $("[name=outerCheckbox]", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("outerCheckbox")).toBe(true);
+    });
+
+    it("the inner checkbox should not be updated", function(){
+      $("[name=outerCheckbox]", this.outerView.$el).removeAttr("checked");
+      $("[name=outerCheckbox]", this.outerView.$el).trigger("change");
+      $("[name=outerCheckbox]", this.outerView.$el).attr("checked", "checked");
+      $("[name=outerCheckbox]", this.outerView.$el).trigger("change");
+      expect(this.innerModel.get("outerCheckbox")).toBe(undefined);
+    });
+  });
+
+  describe("when binding to shared id fields in an inner view", function () {
+    it("the inner text should be updated", function () {
+      $("[name=sharedText]", this.innerView.$el).val("batman");
+      $("[name=sharedText]", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedText")).toBe("batman");
+    });
+
+    it("the outer text should not be updated", function () {
+      $("[name=sharedText]", this.innerView.$el).val("robin");
+      $("[name=sharedText]", this.innerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedText")).toBe(undefined);
+    });
+
+    it("the inner select should be updated", function () {
+      $("[name=sharedSelect]", this.innerView.$el).val("college");
+      $("[name=sharedSelect]", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedSelect")).toBe("college");
+    });
+
+    it("the outer select should not be updated", function () {
+      $("[name=sharedSelect]", this.innerView.$el).val("graduate");
+      $("[name=sharedSelect]", this.innerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedSelect")).toBe("none");
+    });
+
+    it("the inner radio should be updated", function () {
+      $("#graduated_maybe[name=sharedRadio]", this.innerView.$el).attr("checked", "checked");
+      $("#graduated_maybe[name=sharedRadio]", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedRadio")).toBe("maybe");
+    });
+
+    it("the outer radio should not be updated", function () {
+      $("[name=graduated_yes][name=sharedRadio]", this.innerView.$el).attr("checked", "checked");
+      $("[name=graduated_yes][name=sharedRadio]", this.innerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedRadio")).toBe(undefined);
+    });
+
+    it("the inner checkbox should be updated", function () {
+      $("[name=sharedCheckbox]", this.innerView.$el).removeAttr("checked");
+      $("[name=sharedCheckbox]", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedCheckbox")).toBe(false);
+      $("[name=sharedCheckbox]", this.innerView.$el).attr("checked", "checked");
+      $("[name=sharedCheckbox]", this.innerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedCheckbox")).toBe(true);
+    });
+
+    it("the outer checkbox should not be updated", function () {
+      $("[name=sharedCheckbox]", this.innerView.$el).removeAttr("checked");
+      $("[name=sharedCheckbox]", this.innerView.$el).trigger("change");
+      $("[name=sharedCheckbox]", this.innerView.$el).attr("checked", "checked");
+      $("[name=sharedCheckbox]", this.innerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedCheckbox")).toBe(false);
+    });
+  });
+
+  describe("when binding to shared id fields in an outer view", function () {
+    it("the outer text should be updated", function () {
+      $("[name=sharedText]:first", this.outerView.$el).val("batman");
+      $("[name=sharedText]", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedText")).toBe("batman");
+    });
+
+    it("the inner text should not be updated", function () {
+      $("[name=sharedText]:first", this.outerView.$el).val("robin");
+      $("[name=sharedText]:first", this.outerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedText")).toBe(undefined);
+    });
+
+    it("the outer select should be updated", function () {
+      $("[name=sharedSelect]:first", this.outerView.$el).val("college");
+      $("[name=sharedSelect]:first", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedSelect")).toBe("college");
+    });
+
+    it("the inner select should not be updated", function () {
+      $("[name=sharedSelect]:first", this.outerView.$el).val("graduate");
+      $("[name=sharedSelect]:first", this.outerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedSelect")).toBe("none");
+    });
+
+    it("the outer radio should be updated", function () {
+      $("#graduated_maybe[name=sharedRadio]:first", this.outerView.$el).attr("checked", "checked");
+      $("#graduated_maybe[name=sharedRadio]:first", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedRadio")).toBe("maybe");
+    });
+
+    it("the inner radio should not be updated", function () {
+      $("#graduated_yes[name=sharedRadio]:first", this.outerView.$el).attr("checked", "checked");
+      $("#name=graduated_yes[name=sharedRadio]:first", this.outerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedRadio")).toBe(undefined);
+    });
+
+    it("the outer checkbox should be updated", function () {
+      $("[name=sharedCheckbox]:first", this.outerView.$el).removeAttr("checked");
+      $("[name=sharedCheckbox]:first", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedCheckbox")).toBe(false);
+      $("[name=sharedCheckbox]:first", this.outerView.$el).attr("checked", "checked");
+      $("[name=sharedCheckbox]:first", this.outerView.$el).trigger("change");
+      expect(this.outerModel.get("sharedCheckbox")).toBe(true);
+    });
+
+    it("the inner checkbox should not be updated", function () {
+      $("[name=sharedCheckbox]:first", this.outerView.$el).attr("checked", "checked");
+      $("[name=sharedCheckbox]:first", this.outerView.$el).trigger("change");
+      expect(this.innerModel.get("sharedCheckbox")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Hi Derick,

I've added an optional binding configuration option for a callback named 'shouldBindToEl' which takes an element as an argument and returns true or false if the element should be bound to the view’s model.  This allows views to contain nested views that are independently bound to nested models.  Views can define which sub elements are bound to the view’s model allowing nested view elements to be bound to nested models. This callback also allows a view to specify that certain sub elements should be ignored by the model binders.

Here's an example...
  PersonModel has an Address and a Car

PersonModelView has a nestedAddressView and a nestedCarView

```
 ModelBinding.bind(this, { shouldBindToEl: function(el){return el.parent().attr('id') === 'personViewDiv';});
 ModelBinding.bind(nestedAddressView, { shouldBindToEl: function(el){return el.parent().attr('id') === 'address1Div';});
  ModelBinding.bind(nestedCarView, { shouldBindToEl: function(el){return el.parent().attr('id') === 'car1Div';});
```

The shouldBindToEl callbacks rely on their corresponding view structure to determine their own boundaries.

I prefer this approach rather than using nested 'person.address' style syntax.  It does require having nested Backbone.View's defined but you can just use the generic class Backbone.View if the nested view doesn't have any special logic.

I work on a large app with about 20 other developers.  We like the 2 way model binding plugin you've written - it's great but it doesn't work well with nested models / nested views.  Probably about 1/2 of our top level views have nested models (a reusable Address Model + View is a good example).  We run into problems where the nested views update parent models unless we are careful on the order of binding which is not ideal. Also there are times when we want a particular field ignored by the model binder.

What we needed was a way to define the boundaries for the model binder - exactly which elements are to participate in the model binding.  The callback 'shouldBindToEl' gives us this flexibility - the bound view has to define what the boundaries are and the model binders ask for this boundary.

I added 64 new unit tests for this functionality.  32 use the id attribute and 32 use the name attribute - we try to use the name attribute (especially with nested models where the same view definition is repeated and the id will be repeated) so I wanted to make sure there were no issues binding to name.  

I've done some performance testing with a page with 500 outer view elements and 100 inner view elements and checked the binding from the view to the model and the model to the view and there is not a difference is execution speed with the enhancement.
