### PR TITLE
Adds support for checkbox arrays

### DIFF
--- a/spec/SpecRunner.html
+++ b/spec/SpecRunner.html
@@ -42,7 +42,7 @@
 
   <!-- include source files here... -->
   <script type="text/javascript" src="../public/javascripts/underscore.js"></script>
-  <script type="text/javascript" src="../public/javascripts/jquery-1.6.2.js"></script>
+  <script type="text/javascript" src="../public/javascripts/jquery.js"></script>
   <script type="text/javascript" src="../public/javascripts/backbone.js"></script>
   <script type="text/javascript" src="../backbone.modelbinding.js"></script>
 

--- a/spec/javascripts/checkboxConventionBindings.spec.js
+++ b/spec/javascripts/checkboxConventionBindings.spec.js
@@ -5,9 +5,24 @@ describe("checkbox convention bindings", function(){
       this.model = new AModel({
         drivers_license: true,
         motorcycle_license: false,
+        endorsements: ['class_a', 'class_b']
       });
       this.view = new AView({model: this.model});
       this.view.render();
+    });
+
+    it("bind array removal to the model's array field", function(){
+      var el = this.view.$("#endorsements\\[\\][value=class_c]");
+      el.attr("checked");
+      el.trigger('change');
+      expect(this.model.get('endorsements')).toContain('class_c');
+    });
+
+    it("bind array removal to the model's array field", function(){
+      var el = this.view.$("#endorsements\\[\\][value=class_a]");
+      el.removeAttr("checked");
+      el.trigger('change');
+      expect(this.model.get('endorsements')).not.toContain('class_a');
     });
 
     it("bind view changes to the model's field", function(){

--- a/spec/javascripts/checkboxConventionBindings.spec.js
+++ b/spec/javascripts/checkboxConventionBindings.spec.js
@@ -5,24 +5,9 @@ describe("checkbox convention bindings", function(){
       this.model = new AModel({
         drivers_license: true,
         motorcycle_license: false,
-        endorsements: ['class_a', 'class_b']
       });
       this.view = new AView({model: this.model});
       this.view.render();
-    });
-
-    it("bind array removal to the model's array field", function(){
-      var el = this.view.$("#endorsements\\[\\][value=class_c]");
-      el.attr("checked");
-      el.trigger('change');
-      expect(this.model.get('endorsements')).toContain('class_c');
-    });
-
-    it("bind array removal to the model's array field", function(){
-      var el = this.view.$("#endorsements\\[\\][value=class_a]");
-      el.removeAttr("checked");
-      el.trigger('change');
-      expect(this.model.get('endorsements')).not.toContain('class_a');
     });
 
     it("bind view changes to the model's field", function(){
@@ -31,7 +16,7 @@ describe("checkbox convention bindings", function(){
       el.trigger('change');
       expect(this.model.get('drivers_license')).toBeFalsy();
     });
-
+    
     it("bind model field changes to the form input", function(){
       var el = this.view.$("#drivers_license");
 
@@ -105,6 +90,52 @@ describe("checkbox convention bindings", function(){
       expect(selected).toBeTruthy();
     });
   });
+
+  describe("when binding an array to a checkbox", function(){
+    beforeEach(function(){
+      this.model = new AModel({
+        endorsements: ['class_a', 'class_b']
+      });
+      this.view = new AView({model: this.model});
+      this.view.render();
+    });
+
+    it("bind addition to the model's field", function(){
+      var el = this.view.$("#endorsements\\[\\][value=class_c]");
+      el.attr("checked", true);
+      el.trigger('change');
+      expect(this.model.get('endorsements')).toContain('class_c');
+    });
+
+    it("bind removal to the model's field", function(){
+      expect(this.model.get('endorsements')).toContain('class_a');
+      var el = this.view.$("#endorsements\\[\\][value=class_a]");
+      el.removeAttr("checked");
+      el.trigger('change');
+      expect(this.model.get('endorsements')).not.toContain('class_a');
+    });
+
+    it("bind model field changes to the form input", function(){
+      var el = this.view.$("#endorsements\\[\\][value=class_a]");
+
+      // uncheck it
+      this.model.set({endorsements: ['class_b']});
+      var selected = el.attr("checked");
+      expect(selected).toBeFalsy();
+
+      // then check it
+      this.model.set({endorsements: ['class_a']});
+      var selected = el.attr("checked");
+      expect(selected).toBeTruthy();
+    });
+    
+     it("unchecks the box for a falsy value, on render", function(){
+      var el = this.view.$("#endorsements\\[\\][value=class_c]");
+      var selected = el.attr("checked");
+
+      expect(selected).toBeFalsy();
+    });
+  }); 
 
   describe("when there is no value in the model", function(){
     beforeEach(function(){

--- a/spec/javascripts/helpers/sample.backbone.app.js
+++ b/spec/javascripts/helpers/sample.backbone.app.js
@@ -52,6 +52,9 @@ AView = Backbone.View.extend({
       <input type='checkbox' id='drivers_license' value='yes'>\
       <input type='checkbox' id='motorcycle_license' value='yes' checked='checked'>\
       <input type='checkbox' id='binary_checkbox' value='yes'>\
+      <input type='checkbox' id='endorsements[]', value='class_a'>\
+      <input type='checkbox' id='endorsements[]', value='class_b'>\
+      <input type='checkbox' id='endorsements[]', value='class_c'>\
       <textarea id='bio'></textarea>\
       <p id='aParagraph'></p>\
       <input type='password' id='password'>\


### PR DESCRIPTION
Checkboxes can now be given an identifier terminating
in `[]` to denote that the value attribute should be used
as an array key.  For example, given the following form

```
<input type="checkbox" id="foo[]" value="bar"/>
<input type="checkbox" id="foo[]" value="baz" checked="checked"/>
```

the model binding would generate an array `Model.foo = ['baz']`

Setting the value to another array updates the checkbox states, so

```
Model.set('foo', ['bar'])
```

would produce

```
<input type="checkbox" id="foo[]" value="bar" checked="checked"/>
<input type="checkbox" id="foo[]" value="baz" />
```

in the view.
