### PR TITLE
Don't add "undefined" attribute to model

### DIFF
--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -65,7 +65,7 @@ var modelbinding = (function(Backbone, _, $) {
 
     this.registerDataBinding = function(model, eventName, callback){
       // bind the model changes to the elements
-      
+
       model.bind(eventName, callback);
       this.modelBindings.push({model: model, eventName: eventName, callback: callback});
     };
@@ -83,7 +83,7 @@ var modelbinding = (function(Backbone, _, $) {
   modelBinding.Configuration = function(options){
     this.bindingAttrConfig = {};
 
-    _.extend(this.bindingAttrConfig, 
+    _.extend(this.bindingAttrConfig,
       modelBinding.Configuration.bindindAttrConfig,
       options
     );
@@ -98,8 +98,8 @@ var modelbinding = (function(Backbone, _, $) {
       }
     }
 
-    this.getBindingAttr = function(type){ 
-      return this.bindingAttrConfig[type]; 
+    this.getBindingAttr = function(type){
+      return this.bindingAttrConfig[type];
     };
 
     this.getBindingValue = function(element, type){
@@ -180,6 +180,7 @@ var modelbinding = (function(Backbone, _, $) {
         var element = view.$(this);
         var elementType = _getElementType(element);
         var attribute_name = config.getBindingValue(element, elementType);
+        if(typeof attribute_name === "undefined") return true;
 
         var modelChange = function(changed_model, val){ element.val(val); };
 
@@ -224,6 +225,7 @@ var modelbinding = (function(Backbone, _, $) {
       view.$(selector).each(function(index){
         var element = view.$(this);
         var attribute_name = config.getBindingValue(element, 'select');
+        if(typeof attribute_name === "undefined") return true;
 
         var modelChange = function(changed_model, val){ element.val(val); };
 
@@ -248,7 +250,7 @@ var modelbinding = (function(Backbone, _, $) {
         var attr_value = model.get(attribute_name);
         if (typeof attr_value !== "undefined" && attr_value !== null) {
           element.val(attr_value);
-        } 
+        }
 
         // set the model to the form's value if there is no model value
         if (element.val() != attr_value) {
@@ -276,6 +278,8 @@ var modelbinding = (function(Backbone, _, $) {
         var element = view.$(this);
 
         var group_name = config.getBindingValue(element, 'radio');
+        if(typeof group_name === "undefined") return true;
+
         if (!foundElements[group_name]) {
           foundElements[group_name] = true;
           var bindingAttr = config.getBindingAttr('radio');
@@ -337,6 +341,7 @@ var modelbinding = (function(Backbone, _, $) {
         var element = view.$(this);
         var bindingAttr = config.getBindingAttr('checkbox');
         var attribute_name = config.getBindingValue(element, 'checkbox');
+        if(typeof attribute_name === "undefined") return true;
 
         var modelChange = function(model, val){
           if (val){


### PR DESCRIPTION
HTML `<input type="text" />`

Model binding `Backbone.ModelBinding.bind(this, {all:'name'});`

as this input without name attribute, ModelBinding will add a "undefined" to model object.

Sumh 42424861@qq.com
