### PR TITLE
Fix for standalone SpecRunner

### DIFF
--- a/spec/SpecRunner.html
+++ b/spec/SpecRunner.html
@@ -42,7 +42,7 @@
 
   <!-- include source files here... -->
   <script type="text/javascript" src="../public/javascripts/underscore.js"></script>
-  <script type="text/javascript" src="../public/javascripts/jquery-1.6.2.js"></script>
+  <script type="text/javascript" src="../public/javascripts/jquery.js"></script>
   <script type="text/javascript" src="../public/javascripts/backbone.js"></script>
   <script type="text/javascript" src="../backbone.modelbinding.js"></script>
 


### PR DESCRIPTION
SpecRunner is referencing public/javascripts/jquery-1.6.2.js, but the file is just called jquery.js.

This is why the SpecRunner consistently fails.
