### PR TITLE
Add null checking to data-bind text model properties.

### DIFF
--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -409,7 +409,7 @@ var modelbinding = (function(Backbone, _, $) {
 
     modelBinding.Configuration.getDataBindSubst = function(elementType, value){
       var returnValue = value;
-      if (value === undefined){
+      if (value === undefined || value === null){
         if (dataBindSubstConfig.hasOwnProperty(elementType)){
           returnValue = dataBindSubstConfig[elementType];
         } else {

--- a/spec/javascripts/dataBindSubstitutions.spec.js
+++ b/spec/javascripts/dataBindSubstitutions.spec.js
@@ -19,6 +19,17 @@ describe("default data-bind substitutions", function(){
     });
   });
 
+//  describe("when binding to a null value on a model property use the default substitution", function(){
+//    beforeEach(function(){
+//      this.model.set("doctor", null);
+//      this.el = this.view.$("#doctor");
+//    });
+//
+//    it("should use the 'default' substitution setting", function(){
+//      expect(this.el.text()).toBe("");
+//    });
+//  });
+
   describe("when binding to text and unsetting the model's property", function(){
     beforeEach(function(){
       this.model.unset("doctor");


### PR DESCRIPTION
When a model has a property that is set to null (coming from the JSON.parse()) the behavior of the data-bind text on Chrome and Firefox is different. On Firefox, the text does not show. On Chrome, the text shows up as null.

I couldn't make the test replicate the issue, but the jsFiddle @ http://jsfiddle.net/TKfQu/6/ demonstrates the problem nicely. Be sure to look a the results in both Firefox and Chrome. 
