### PR TITLE
Do not bind if attribute_name is undefined

### DIFF
--- a/backbone.modelbinding.js
+++ b/backbone.modelbinding.js
@@ -181,6 +181,8 @@ var modelbinding = (function(Backbone, _, $) {
         var elementType = _getElementType(element);
         var attribute_name = config.getBindingValue(element, elementType);
 
+        if (attribute_name === void 0) return;
+
         var modelChange = function(changed_model, val){ element.val(val); };
 
         var setModelValue = function(attr_name, value){


### PR DESCRIPTION
So afeld/backbone-nested doesn't crushes…

If using backbone.modelbind + backbone-nested and mix `StandardBinding` with `DataBindBinding` on input fields - I've got an error `TypeError: 'undefined' is not an object (evaluating 'attrPath[0]')` inside of backbone-nested. Caused by attempt to bind with undefined `attribute_name` in StandardBinding. This is simple fix for that.
